### PR TITLE
Upgrade KiCad symbols to v10 and improve pin type assignments

### DIFF
--- a/src/elec_common/Bluesat.kicad_sym
+++ b/src/elec_common/Bluesat.kicad_sym
@@ -9747,6 +9747,518 @@
 		)
 		(embedded_fonts no)
 	)
+	(symbol "WS2812B-2020"
+		(pin_names
+			(offset 0.254)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(duplicate_pin_numbers_are_jumpers no)
+		(property "Reference" "D"
+			(at 3.048 7.874 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right bottom)
+			)
+		)
+		(property "Value" "WS2812B-2020"
+			(at 1.778 7.366 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left top)
+			)
+		)
+		(property "Footprint" "Bluesat:WS2812B-2020"
+			(at 1.27 -7.62 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left top)
+			)
+		)
+		(property "Datasheet" "https://www.lcsc.com/datasheet/C5349957.pdf"
+			(at 2.54 -9.525 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left top)
+			)
+		)
+		(property "Description" "RGB LED with integrated controller, 2.0 x 2.0 mm, 12 mA"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "ki_keywords" "RGB LED NeoPixel Nano addressable"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "ki_fp_filters" "LED*WS2812*-2020_PLCC4*"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(symbol "WS2812B-2020_0_0"
+			(text "RGB"
+				(at 2.286 -4.191 0)
+				(effects
+					(font
+						(size 0.762 0.762)
+					)
+				)
+			)
+		)
+		(symbol "WS2812B-2020_0_1"
+			(polyline
+				(pts
+					(xy 1.27 -2.54) (xy 1.778 -2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 1.27 -3.556) (xy 1.778 -3.556)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 2.286 -1.524) (xy 1.27 -2.54) (xy 1.27 -2.032)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 2.286 -2.54) (xy 1.27 -3.556) (xy 1.27 -3.048)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 3.683 -1.016) (xy 3.683 -3.556) (xy 3.683 -4.064)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 4.699 -1.524) (xy 2.667 -1.524) (xy 3.683 -3.556) (xy 4.699 -1.524)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 4.699 -3.556) (xy 2.667 -3.556)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(rectangle
+				(start 5.08 5.08)
+				(end -5.08 -5.08)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type background)
+				)
+			)
+		)
+		(symbol "WS2812B-2020_1_1"
+			(pin output line
+				(at 7.62 0 180)
+				(length 2.54)
+				(name "DOUT"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at 0 -7.62 90)
+				(length 2.54)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -7.62 0 0)
+				(length 2.54)
+				(name "DIN"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at 0 7.62 270)
+				(length 2.54)
+				(name "VDD"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "ZD24C128A"
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(duplicate_pin_numbers_are_jumpers no)
+		(property "Reference" "U"
+			(at 2.032 8.382 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "ZD24C128A"
+			(at 1.27 6.35 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Bluesat:TSSOP-8_4.4x3.0-0.65"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" "http://en.zettadevice.com/uploads/files/128Kb%E6%96%B0/16505297604f0ba363f9e5bcec.pdf"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "I2C Serial EEPROM, 128Kb, DIP-8/SOIC-8/TSSOP-8/DFN-8"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "ki_keywords" "I2C Serial EEPROM"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "ki_fp_filters" "DIP*W7.62mm* SOIC*3.9x4.9mm* TSSOP*4.4x3mm*P0.65mm* DFN*3x2mm*P0.5mm*"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(symbol "ZD24C128A_1_1"
+			(rectangle
+				(start -7.62 5.08)
+				(end 7.62 -5.08)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type background)
+				)
+			)
+			(pin input line
+				(at -10.16 2.54 0)
+				(length 2.54)
+				(name "A0"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -10.16 0 0)
+				(length 2.54)
+				(name "A1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -10.16 -2.54 0)
+				(length 2.54)
+				(name "A2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at 0 -7.62 90)
+				(length 2.54)
+				(name "GND"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin open_collector line
+				(at 10.16 2.54 180)
+				(length 2.54)
+				(name "SDA"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at 10.16 0 180)
+				(length 2.54)
+				(name "SCL"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at 10.16 -2.54 180)
+				(length 2.54)
+				(name "WP"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at 0 7.62 270)
+				(length 2.54)
+				(name "VCC"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "8"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
 	(symbol "ZD25WQ16CEIGR"
 		(exclude_from_sim no)
 		(in_bom yes)

--- a/src/elec_common/Bluesat.kicad_sym
+++ b/src/elec_common/Bluesat.kicad_sym
@@ -1,6227 +1,9970 @@
-(kicad_symbol_lib 
-    (version 20241209) 
-    (generator "kicad_symbol_editor") 
-    (generator_version "9.0") 
-    (symbol "+19V" 
-        (power) 
-        (pin_numbers 
-            (hide yes)) 
-        (pin_names 
-            (offset 0) 
-            (hide yes)) 
-        (exclude_from_sim no) 
-        (in_bom yes) 
-        (on_board yes) 
-        (property "Reference" "#PWR" 
-            (at 0 -3.81 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "Value" "+19V" 
-            (at 0 3.556 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)))) 
-        (property "Footprint" "" 
-            (at 0 0 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "Datasheet" "" 
-            (at 0 0 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "Description" "Power symbol creates a global label with name \"+19V\"" 
-            (at 0 0 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "ki_keywords" "global power" 
-            (at 0 0 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (symbol "+19V_0_1" 
-            (polyline 
-                (pts 
-                    (xy -0.762 1.27) 
-                    (xy 0 2.54)) 
-                (stroke 
-                    (width 0) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (polyline 
-                (pts 
-                    (xy 0 2.54) 
-                    (xy 0.762 1.27)) 
-                (stroke 
-                    (width 0) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (polyline 
-                (pts 
-                    (xy 0 0) 
-                    (xy 0 2.54)) 
-                (stroke 
-                    (width 0) 
-                    (type default)) 
-                (fill 
-                    (type none)))) 
-        (symbol "+19V_1_1" 
-            (pin power_in line 
-                (at 0 0 90) 
-                (length 0) 
-                (name "~" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))))) 
-        (embedded_fonts no)) 
-    (symbol "BDFN3310A056R" 
-        (exclude_from_sim no) 
-        (in_bom yes) 
-        (on_board yes) 
-        (property "Reference" "U" 
-            (at 0 -8.89 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)))) 
-        (property "Value" "BDFN3310A056R" 
-            (at 0 -10.414 0) 
-            (effects 
-                (font 
-                    (size 1.016 1.016)))) 
-        (property "Footprint" "Bluesat:UDFN8_3P3X1_517CB_ONS" 
-            (at 1.524 12.192 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "Datasheet" "https://www.lcsc.com/datasheet/C600810.pdf" 
-            (at 0.762 10.16 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "Description" "6-in-1 TVS diode for USB 3V3" 
-            (at 1.27 14.224 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (symbol "BDFN3310A056R_1_0" 
-            (pin power_in line 
-                (at 11.43 -5.08 180) 
-                (length 2.54) 
-                (hide yes) 
-                (name "GND" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "10" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at 11.43 -5.08 180) 
-                (length 2.54) 
-                (hide yes) 
-                (name "GND" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "6" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at 11.43 -5.08 180) 
-                (length 2.54) 
-                (hide yes) 
-                (name "GND" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "9" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))))) 
-        (symbol "BDFN3310A056R_1_1" 
-            (rectangle 
-                (start -8.89 0) 
-                (end 8.89 -7.62) 
-                (stroke 
-                    (width 0) 
-                    (type solid)) 
-                (fill 
-                    (type background))) 
-            (pin input line 
-                (at -6.35 2.54 270) 
-                (length 2.54) 
-                (name "IO1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at -3.81 2.54 270) 
-                (length 2.54) 
-                (name "IO2" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "2" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at -1.27 2.54 270) 
-                (length 2.54) 
-                (name "IO3" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "4" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at 1.27 2.54 270) 
-                (length 2.54) 
-                (name "IO4" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "5" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at 3.81 2.54 270) 
-                (length 2.54) 
-                (name "IO5" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "7" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at 6.35 2.54 270) 
-                (length 2.54) 
-                (name "IO6" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "8" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at 11.43 -5.08 180) 
-                (length 2.54) 
-                (name "GND" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "3" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))))) 
-        (embedded_fonts no)) 
-    (symbol "C_CompactH" 
-        (pin_numbers 
-            (hide yes)) 
-        (pin_names 
-            (offset 0.254) 
-            (hide yes)) 
-        (exclude_from_sim no) 
-        (in_bom yes) 
-        (on_board yes) 
-        (property "Reference" "C" 
-            (at 0.762 0.889 0) 
-            (do_not_autoplace) 
-            (effects 
-                (font 
-                    (size 1.016 1.016)) 
-                (justify left))) 
-        (property "Value" "C_CompactH" 
-            (at -0.762 0.889 0) 
-            (do_not_autoplace) 
-            (effects 
-                (font 
-                    (size 1.016 1.016)) 
-                (justify right))) 
-        (property "Footprint" "" 
-            (at 0 0 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "Datasheet" "~" 
-            (at 0 0 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "Description" "Unpolarized capacitor, compact symbol" 
-            (at 0 0 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "ki_keywords" "capacitor cap" 
-            (at 0 0 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "ki_fp_filters" "C_*" 
-            (at 0 0 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (symbol "C_CompactH_0_1" 
-            (polyline 
-                (pts 
-                    (xy -0.508 -1.524) 
-                    (xy -0.508 1.524)) 
-                (stroke 
-                    (width 0.3048) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (polyline 
-                (pts 
-                    (xy 0.508 -1.524) 
-                    (xy 0.508 1.524)) 
-                (stroke 
-                    (width 0.3302) 
-                    (type default)) 
-                (fill 
-                    (type none)))) 
-        (symbol "C_CompactH_1_1" 
-            (pin passive line 
-                (at -2.54 0 0) 
-                (length 2.032) 
-                (name "~" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at 2.54 0 180) 
-                (length 2.032) 
-                (name "~" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "2" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))))) 
-        (embedded_fonts no)) 
-    (symbol "C_CompactV" 
-        (pin_numbers 
-            (hide yes)) 
-        (pin_names 
-            (offset 0.254) 
-            (hide yes)) 
-        (exclude_from_sim no) 
-        (in_bom yes) 
-        (on_board yes) 
-        (property "Reference" "C" 
-            (at -0.889 0.762 90) 
-            (do_not_autoplace) 
-            (effects 
-                (font 
-                    (size 1.016 1.016)) 
-                (justify left))) 
-        (property "Value" "C_CompactV" 
-            (at 0.889 0.762 90) 
-            (do_not_autoplace) 
-            (effects 
-                (font 
-                    (size 1.016 1.016)) 
-                (justify left))) 
-        (property "Footprint" "" 
-            (at 0 0 90) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "Datasheet" "~" 
-            (at 0 0 90) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "Description" "Unpolarized capacitor, compact symbol" 
-            (at 0 0 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "ki_keywords" "capacitor cap" 
-            (at 0 0 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "ki_fp_filters" "C_*" 
-            (at 0 0 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (symbol "C_CompactV_0_1" 
-            (polyline 
-                (pts 
-                    (xy 1.524 0.508) 
-                    (xy -1.524 0.508)) 
-                (stroke 
-                    (width 0.3302) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (polyline 
-                (pts 
-                    (xy 1.524 -0.508) 
-                    (xy -1.524 -0.508)) 
-                (stroke 
-                    (width 0.3048) 
-                    (type default)) 
-                (fill 
-                    (type none)))) 
-        (symbol "C_CompactV_1_1" 
-            (pin passive line 
-                (at 0 2.54 270) 
-                (length 2.032) 
-                (name "~" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "2" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at 0 -2.54 90) 
-                (length 2.032) 
-                (name "~" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))))) 
-        (embedded_fonts no)) 
-    (symbol "DMHT6016LFJ" 
-        (exclude_from_sim no) 
-        (in_bom yes) 
-        (on_board yes) 
-        (property "Reference" "U" 
-            (at 0 4.318 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)))) 
-        (property "Value" "DMHT6016LFJ" 
-            (at -0.254 6.35 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)))) 
-        (property "Footprint" "Bluesat:VDFN5045-12" 
-            (at 0.508 -20.066 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "Datasheet" "https://www.diodes.com/assets/Datasheets/DMHT6016LFJ.pdf" 
-            (at 0.254 -21.844 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "Description" "60V N-channel enhancement mode MOSFET H-bridge" 
-            (at 0.762 -18.034 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (symbol "DMHT6016LFJ_1_1" 
-            (rectangle 
-                (start -12.7 7.62) 
-                (end 12.7 -7.62) 
-                (stroke 
-                    (width 0) 
-                    (type solid)) 
-                (fill 
-                    (type background))) 
-            (pin input line 
-                (at -15.24 3.81 0) 
-                (length 2.54) 
-                (name "G1_AH" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at -15.24 1.27 0) 
-                (length 2.54) 
-                (name "G2_AL" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "4" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at -15.24 -1.27 0) 
-                (length 2.54) 
-                (name "G4_BH" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "12" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at -15.24 -3.81 0) 
-                (length 2.54) 
-                (name "G3_BL" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "9" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at -1.27 -10.16 90) 
-                (length 2.54) 
-                (name "S2_A" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "5" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at -1.27 -10.16 90) 
-                (length 2.54) 
-                (hide yes) 
-                (name "S2_A" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "6" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at 0 10.16 270) 
-                (length 2.54) 
-                (hide yes) 
-                (name "D1/D4" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "11" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at 0 10.16 270) 
-                (length 2.54) 
-                (name "D1/D4" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "2" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at 0 10.16 270) 
-                (length 2.54) 
-                (hide yes) 
-                (name "D1/D4" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "A" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at 1.27 -10.16 90) 
-                (length 2.54) 
-                (name "S3_B" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "7" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at 1.27 -10.16 90) 
-                (length 2.54) 
-                (hide yes) 
-                (name "S3_B" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "8" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_out line 
-                (at 15.24 1.27 180) 
-                (length 2.54) 
-                (name "S1/D2_A" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "3" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin free line 
-                (at 15.24 1.27 180) 
-                (length 2.54) 
-                (hide yes) 
-                (name "S1/D2_A" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "B" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_out line 
-                (at 15.24 -1.27 180) 
-                (length 2.54) 
-                (name "S4/D3_B" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "10" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin free line 
-                (at 15.24 -1.27 180) 
-                (length 2.54) 
-                (hide yes) 
-                (name "S4/D3_B" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "C" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))))) 
-        (embedded_fonts no)) 
-    (symbol "D_TVS_Dual_Compact" 
-        (pin_names 
-            (offset 1.016) 
-            (hide yes)) 
-        (exclude_from_sim no) 
-        (in_bom yes) 
-        (on_board yes) 
-        (property "Reference" "D" 
-            (at 0 6.35 0) 
-            (effects 
-                (font 
-                    (size 1.016 1.016)))) 
-        (property "Value" "D_TVS_Dual_Compact" 
-            (at 0 5.08 0) 
-            (effects 
-                (font 
-                    (size 1.016 1.016)))) 
-        (property "Footprint" "" 
-            (at 0 0 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "Datasheet" "~" 
-            (at 0 0 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "Description" "Dual bidirectional transient-voltage-suppression diode, compact symbol (suggested: RCLAMP0502B)" 
-            (at 0.254 12.7 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "ki_keywords" "diode TVS thyrector" 
-            (at 0 0 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "ki_fp_filters" "TO-???* *_Diode_* *SingleDiode* D_*" 
-            (at 0 0 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (symbol "D_TVS_Dual_Compact_0_1" 
-            (polyline 
-                (pts 
-                    (xy -1.27 1.27) 
-                    (xy -1.27 -1.27)) 
-                (stroke 
-                    (width 0) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (polyline 
-                (pts 
-                    (xy -1.27 -1.27) 
-                    (xy -1.27 -1.905) 
-                    (xy 1.27 -1.905) 
-                    (xy 1.27 -1.27)) 
-                (stroke 
-                    (width 0) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (polyline 
-                (pts 
-                    (xy -0.254 1.27) 
-                    (xy -2.286 1.27) 
-                    (xy -0.254 -1.27) 
-                    (xy -2.286 -1.27) 
-                    (xy -0.254 1.27)) 
-                (stroke 
-                    (width 0.254) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (polyline 
-                (pts 
-                    (xy -0.254 -0.508) 
-                    (xy -0.254 0) 
-                    (xy -2.286 0) 
-                    (xy -2.286 0.508)) 
-                (stroke 
-                    (width 0.254) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (polyline 
-                (pts 
-                    (xy 1.27 1.27) 
-                    (xy 1.27 -1.27)) 
-                (stroke 
-                    (width 0) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (polyline 
-                (pts 
-                    (xy 2.286 1.27) 
-                    (xy 0.254 1.27) 
-                    (xy 2.286 -1.27) 
-                    (xy 0.254 -1.27) 
-                    (xy 2.286 1.27)) 
-                (stroke 
-                    (width 0.254) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (polyline 
-                (pts 
-                    (xy 2.286 -0.508) 
-                    (xy 2.286 0) 
-                    (xy 0.254 0) 
-                    (xy 0.254 0.508)) 
-                (stroke 
-                    (width 0.254) 
-                    (type default)) 
-                (fill 
-                    (type none)))) 
-        (symbol "D_TVS_Dual_Compact_1_1" 
-            (rectangle 
-                (start -2.794 2.54) 
-                (end 2.794 -2.54) 
-                (stroke 
-                    (width 0) 
-                    (type solid)) 
-                (fill 
-                    (type background))) 
-            (polyline 
-                (pts 
-                    (xy -1.27 1.27) 
-                    (xy -1.27 2.54)) 
-                (stroke 
-                    (width 0) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (polyline 
-                (pts 
-                    (xy 0 -2.54) 
-                    (xy 0 -1.905)) 
-                (stroke 
-                    (width 0) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (polyline 
-                (pts 
-                    (xy 1.27 2.54) 
-                    (xy 1.27 2.54)) 
-                (stroke 
-                    (width 0) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (polyline 
-                (pts 
-                    (xy 1.27 2.54) 
-                    (xy 1.27 1.27)) 
-                (stroke 
-                    (width 0) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (polyline 
-                (pts 
-                    (xy 1.27 1.27) 
-                    (xy 1.27 1.27)) 
-                (stroke 
-                    (width 0) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (pin passive line 
-                (at -1.27 3.81 270) 
-                (length 1.27) 
-                (name "" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at 0 -3.81 90) 
-                (length 1.27) 
-                (name "" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "3" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at 1.27 3.81 270) 
-                (length 1.27) 
-                (name "" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "2" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))))) 
-        (embedded_fonts no)) 
-    (symbol "D_TVS_Quad_Compact" 
-        (pin_names 
-            (offset 1.016) 
-            (hide yes)) 
-        (exclude_from_sim no) 
-        (in_bom yes) 
-        (on_board yes) 
-        (property "Reference" "D" 
-            (at 0 6.35 0) 
-            (effects 
-                (font 
-                    (size 1.016 1.016)))) 
-        (property "Value" "D_TVS_Quad_Compact" 
-            (at 0 5.08 0) 
-            (effects 
-                (font 
-                    (size 1.016 1.016)))) 
-        (property "Footprint" "" 
-            (at 0 0 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "Datasheet" "~" 
-            (at 0 0 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "Description" "Quad bidirectional transient-voltage-suppression diode, compact symbol (suggested: TPAZ1143-04F)" 
-            (at 0.254 12.7 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "ki_keywords" "diode TVS thyrector" 
-            (at 0 0 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "ki_fp_filters" "TO-???* *_Diode_* *SingleDiode* D_*" 
-            (at 0 0 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (symbol "D_TVS_Quad_Compact_0_1" 
-            (polyline 
-                (pts 
-                    (xy -3.81 1.27) 
-                    (xy -3.81 -1.27)) 
-                (stroke 
-                    (width 0) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (polyline 
-                (pts 
-                    (xy -2.794 1.27) 
-                    (xy -4.826 1.27) 
-                    (xy -2.794 -1.27) 
-                    (xy -4.826 -1.27) 
-                    (xy -2.794 1.27)) 
-                (stroke 
-                    (width 0.254) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (polyline 
-                (pts 
-                    (xy -2.794 -0.508) 
-                    (xy -2.794 0) 
-                    (xy -4.826 0) 
-                    (xy -4.826 0.508)) 
-                (stroke 
-                    (width 0.254) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (polyline 
-                (pts 
-                    (xy -1.27 1.27) 
-                    (xy -1.27 -1.27)) 
-                (stroke 
-                    (width 0) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (polyline 
-                (pts 
-                    (xy -0.254 1.27) 
-                    (xy -2.286 1.27) 
-                    (xy -0.254 -1.27) 
-                    (xy -2.286 -1.27) 
-                    (xy -0.254 1.27)) 
-                (stroke 
-                    (width 0.254) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (polyline 
-                (pts 
-                    (xy -0.254 -0.508) 
-                    (xy -0.254 0) 
-                    (xy -2.286 0) 
-                    (xy -2.286 0.508)) 
-                (stroke 
-                    (width 0.254) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (polyline 
-                (pts 
-                    (xy 1.27 1.27) 
-                    (xy 1.27 -1.27)) 
-                (stroke 
-                    (width 0) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (polyline 
-                (pts 
-                    (xy 2.286 1.27) 
-                    (xy 0.254 1.27) 
-                    (xy 2.286 -1.27) 
-                    (xy 0.254 -1.27) 
-                    (xy 2.286 1.27)) 
-                (stroke 
-                    (width 0.254) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (polyline 
-                (pts 
-                    (xy 2.286 -0.508) 
-                    (xy 2.286 0) 
-                    (xy 0.254 0) 
-                    (xy 0.254 0.508)) 
-                (stroke 
-                    (width 0.254) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (polyline 
-                (pts 
-                    (xy 3.81 1.27) 
-                    (xy 3.81 -1.27)) 
-                (stroke 
-                    (width 0) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (polyline 
-                (pts 
-                    (xy 4.826 1.27) 
-                    (xy 2.794 1.27) 
-                    (xy 4.826 -1.27) 
-                    (xy 2.794 -1.27) 
-                    (xy 4.826 1.27)) 
-                (stroke 
-                    (width 0.254) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (polyline 
-                (pts 
-                    (xy 4.826 -0.508) 
-                    (xy 4.826 0) 
-                    (xy 2.794 0) 
-                    (xy 2.794 0.508)) 
-                (stroke 
-                    (width 0.254) 
-                    (type default)) 
-                (fill 
-                    (type none)))) 
-        (symbol "D_TVS_Quad_Compact_1_1" 
-            (rectangle 
-                (start -5.334 2.54) 
-                (end 5.334 -2.54) 
-                (stroke 
-                    (width 0) 
-                    (type solid)) 
-                (fill 
-                    (type background))) 
-            (polyline 
-                (pts 
-                    (xy -3.81 2.54) 
-                    (xy -3.81 1.27)) 
-                (stroke 
-                    (width 0) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (polyline 
-                (pts 
-                    (xy -3.81 -1.905) 
-                    (xy -3.81 -1.27)) 
-                (stroke 
-                    (width 0) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (polyline 
-                (pts 
-                    (xy -3.81 -1.905) 
-                    (xy 3.81 -1.905)) 
-                (stroke 
-                    (width 0) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (polyline 
-                (pts 
-                    (xy -1.27 1.27) 
-                    (xy -1.27 2.54)) 
-                (stroke 
-                    (width 0) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (polyline 
-                (pts 
-                    (xy -1.27 -1.905) 
-                    (xy -1.27 -1.27)) 
-                (stroke 
-                    (width 0) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (polyline 
-                (pts 
-                    (xy 0 -2.54) 
-                    (xy 0 -1.905)) 
-                (stroke 
-                    (width 0) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (polyline 
-                (pts 
-                    (xy 1.27 2.54) 
-                    (xy 1.27 2.54)) 
-                (stroke 
-                    (width 0) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (polyline 
-                (pts 
-                    (xy 1.27 2.54) 
-                    (xy 1.27 1.27)) 
-                (stroke 
-                    (width 0) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (polyline 
-                (pts 
-                    (xy 1.27 1.27) 
-                    (xy 1.27 1.27)) 
-                (stroke 
-                    (width 0) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (polyline 
-                (pts 
-                    (xy 1.27 -1.905) 
-                    (xy 1.27 -1.27)) 
-                (stroke 
-                    (width 0) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (polyline 
-                (pts 
-                    (xy 3.81 2.54) 
-                    (xy 3.81 1.27)) 
-                (stroke 
-                    (width 0) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (polyline 
-                (pts 
-                    (xy 3.81 -1.905) 
-                    (xy 3.81 -1.27)) 
-                (stroke 
-                    (width 0) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (polyline 
-                (pts 
-                    (xy 3.81 -1.905) 
-                    (xy 3.81 -1.905)) 
-                (stroke 
-                    (width 0) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (pin passive line 
-                (at -3.81 3.81 270) 
-                (length 1.27) 
-                (name "" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at -3.81 3.81 270) 
-                (length 1.27) 
-                (hide yes) 
-                (name "" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "10" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at -1.27 3.81 270) 
-                (length 1.27) 
-                (name "" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "2" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at -1.27 3.81 270) 
-                (length 1.27) 
-                (hide yes) 
-                (name "" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "9" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at 0 -3.81 90) 
-                (length 1.27) 
-                (name "" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "3" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at 0 -3.81 90) 
-                (length 1.27) 
-                (hide yes) 
-                (name "" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "8" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at 1.27 3.81 270) 
-                (length 1.27) 
-                (name "" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "4" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at 1.27 3.81 270) 
-                (length 1.27) 
-                (hide yes) 
-                (name "" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "7" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at 3.81 3.81 270) 
-                (length 1.27) 
-                (name "" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "5" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at 3.81 3.81 270) 
-                (length 1.27) 
-                (hide yes) 
-                (name "" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "6" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))))) 
-        (embedded_fonts no)) 
-    (symbol "IDC_6P" 
-        (exclude_from_sim no) 
-        (in_bom yes) 
-        (on_board yes) 
-        (property "Reference" "J" 
-            (at 0 7.366 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)))) 
-        (property "Value" "IDC_6P" 
-            (at 0 0 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)))) 
-        (property "Footprint" "Bluesat:IDC6" 
-            (at 0 0 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "Datasheet" "Bluesat OWR docs: standard/electrical/device#debugging" 
-            (at 0 0 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "Description" "6-pin IDC MCU debug header (socket for debuggers)" 
-            (at 0 0 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (symbol "IDC_6P_1_1" 
-            (rectangle 
-                (start -5.08 3.81) 
-                (end 6.35 -3.81) 
-                (stroke 
-                    (width 0.254) 
-                    (type default)) 
-                (fill 
-                    (type background))) 
-            (rectangle 
-                (start -5.08 2.667) 
-                (end -3.81 2.413) 
-                (stroke 
-                    (width 0.1524) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (rectangle 
-                (start -5.08 0.127) 
-                (end -3.81 -0.127) 
-                (stroke 
-                    (width 0.1524) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (rectangle 
-                (start -5.08 -2.413) 
-                (end -3.81 -2.667) 
-                (stroke 
-                    (width 0.1524) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (rectangle 
-                (start 6.35 2.667) 
-                (end 5.08 2.413) 
-                (stroke 
-                    (width 0.1524) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (rectangle 
-                (start 6.35 0.127) 
-                (end 5.08 -0.127) 
-                (stroke 
-                    (width 0.1524) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (rectangle 
-                (start 6.35 -2.413) 
-                (end 5.08 -2.667) 
-                (stroke 
-                    (width 0.1524) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (pin passive line 
-                (at -8.89 2.54 0) 
-                (length 3.81) 
-                (name "SWO" 
-                    (effects 
-                        (font 
-                            (size 1.016 1.016)))) 
-                (number "1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at -8.89 0 0) 
-                (length 3.81) 
-                (name "GND" 
-                    (effects 
-                        (font 
-                            (size 1.016 1.016)))) 
-                (number "3" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at -8.89 -2.54 0) 
-                (length 3.81) 
-                (name "SWDIO" 
-                    (effects 
-                        (font 
-                            (size 0.889 0.889)))) 
-                (number "5" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at 10.16 2.54 180) 
-                (length 3.81) 
-                (name "NRST" 
-                    (effects 
-                        (font 
-                            (size 1.016 1.016)))) 
-                (number "2" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at 10.16 0 180) 
-                (length 3.81) 
-                (name "3V3" 
-                    (effects 
-                        (font 
-                            (size 1.016 1.016)))) 
-                (number "4" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at 10.16 -2.54 180) 
-                (length 3.81) 
-                (name "SWCLK" 
-                    (effects 
-                        (font 
-                            (size 0.889 0.889)))) 
-                (number "6" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))))) 
-        (embedded_fonts no)) 
-    (symbol "ISM330DLC" 
-        (exclude_from_sim no) 
-        (in_bom yes) 
-        (on_board yes) 
-        (property "Reference" "U" 
-            (at 2.54 8.255 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (justify left))) 
-        (property "Value" "ISM330DLC" 
-            (at 2.54 6.35 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (justify left))) 
-        (property "Footprint" "Package_LGA:LGA-14_3x2.5mm_P0.5mm_LayoutBorder3x4y" 
-            (at -0.254 -21.844 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "Datasheet" "https://www.lcsc.com/datasheet/C2943126.pdf" 
-            (at -0.254 -24.13 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "Description" "6 Axis IMU (3 Axis Gyroscope + 3 Axis Accelerometer)" 
-            (at -0.254 -19.558 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (symbol "ISM330DLC_1_1" 
-            (rectangle 
-                (start -7.62 5.08) 
-                (end 7.62 -5.08) 
-                (stroke 
-                    (width 0) 
-                    (type solid)) 
-                (fill 
-                    (type background))) 
-            (pin output line 
-                (at -10.16 2.54 0) 
-                (length 2.54) 
-                (name "INT1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "4" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin output line 
-                (at -10.16 0 0) 
-                (length 2.54) 
-                (name "INT2" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "9" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at -10.16 -2.54 0) 
-                (length 2.54) 
-                (name "CS" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "12" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at -1.27 7.62 270) 
-                (length 2.54) 
-                (name "VIO" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "5" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at -1.27 -7.62 90) 
-                (length 2.54) 
-                (name "RES" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "2" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at -1.27 -7.62 90) 
-                (length 2.54) 
-                (hide yes) 
-                (name "RES" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "3" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at 1.27 7.62 270) 
-                (length 2.54) 
-                (name "VDD" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "8" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at 1.27 -7.62 90) 
-                (length 2.54) 
-                (name "GND" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "6" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at 1.27 -7.62 90) 
-                (length 2.54) 
-                (hide yes) 
-                (name "GND" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "7" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin no_connect line 
-                (at 2.54 -7.62 90) 
-                (length 2.54) 
-                (hide yes) 
-                (name "NC" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "11" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin no_connect line 
-                (at 5.08 -7.62 90) 
-                (length 2.54) 
-                (hide yes) 
-                (name "NC" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "10" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin open_collector line 
-                (at 10.16 2.54 180) 
-                (length 2.54) 
-                (name "SDA" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "14" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin open_collector line 
-                (at 10.16 0 180) 
-                (length 2.54) 
-                (name "SCL" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "13" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 10.16 -2.54 180) 
-                (length 2.54) 
-                (name "SDO" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))))) 
-        (embedded_fonts no)) 
-    (symbol "LIS2MDL" 
-        (exclude_from_sim no) 
-        (in_bom yes) 
-        (on_board yes) 
-        (property "Reference" "U" 
-            (at 1.905 8.255 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (justify left))) 
-        (property "Value" "LIS2MDL" 
-            (at 1.905 6.35 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (justify left))) 
-        (property "Footprint" "Package_LGA:LGA-12_2x2mm_P0.5mm" 
-            (at -0.254 -11.938 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "Datasheet" "https://www.st.com/resource/en/datasheet/lis2mdl.pdf" 
-            (at 0.254 -13.97 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "Description" "3-axis magnetometer (NOT ARCh-LEGAL)" 
-            (at -0.254 -9.652 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (symbol "LIS2MDL_1_1" 
-            (rectangle 
-                (start -7.62 5.08) 
-                (end 7.62 -5.08) 
-                (stroke 
-                    (width 0) 
-                    (type solid)) 
-                (fill 
-                    (type background))) 
-            (text "THIS COMPONENT IS\nNOT ARCh-LEGAL" 
-                (at -13.716 8.636 0) 
-                (effects 
-                    (font 
-                        (size 1.27 1.27)))) 
-            (pin passive line 
-                (at -10.16 2.54 0) 
-                (length 2.54) 
-                (name "C1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "5" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at -10.16 -2.54 0) 
-                (length 2.54) 
-                (name "CS" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "3" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at -1.27 7.62 270) 
-                (length 2.54) 
-                (name "VIO" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "10" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at 0 -7.62 90) 
-                (length 2.54) 
-                (hide yes) 
-                (name "NC" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "11" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at 0 -7.62 90) 
-                (length 2.54) 
-                (hide yes) 
-                (name "NC" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "12" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at 0 -7.62 90) 
-                (length 2.54) 
-                (hide yes) 
-                (name "NC" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "2" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at 0 -7.62 90) 
-                (length 2.54) 
-                (name "GND" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "6" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at 0 -7.62 90) 
-                (length 2.54) 
-                (hide yes) 
-                (name "GND" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "8" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at 1.27 7.62 270) 
-                (length 2.54) 
-                (name "VDD" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "9" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin open_collector line 
-                (at 10.16 2.54 180) 
-                (length 2.54) 
-                (name "SDA" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "4" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin open_collector line 
-                (at 10.16 0 180) 
-                (length 2.54) 
-                (name "SCL" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin output line 
-                (at 10.16 -2.54 180) 
-                (length 2.54) 
-                (name "INT" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "7" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))))) 
-        (embedded_fonts no)) 
-    (symbol "LM5148" 
-        (exclude_from_sim no) 
-        (in_bom yes) 
-        (on_board yes) 
-        (property "Reference" "U" 
-            (at 0 3.048 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)))) 
-        (property "Value" "LM5148" 
-            (at 0 1.27 0) 
-            (effects 
-                (font 
-                    (size 1.016 1.016)))) 
-        (property "Footprint" "Bluesat:RGY0024E-MFG" 
-            (at 0 8.636 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "Datasheet" "https://www.lcsc.com/datasheet/C7470701.pdf" 
-            (at 0 6.604 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "Description" "Large (80V) buck converter" 
-            (at 0 10.668 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (symbol "LM5148_1_0" 
-            (pin passive line 
-                (at 1.27 -31.75 90) 
-                (length 2.54) 
-                (hide yes) 
-                (name "NC" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "25" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))))) 
-        (symbol "LM5148_1_1" 
-            (rectangle 
-                (start -10.16 0) 
-                (end 10.16 -29.21) 
-                (stroke 
-                    (width 0) 
-                    (type solid)) 
-                (fill 
-                    (type background))) 
-            (pin power_in line 
-                (at -12.7 -2.54 0) 
-                (length 2.54) 
-                (name "VIN" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "12" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_out line 
-                (at -12.7 -5.08 0) 
-                (length 2.54) 
-                (name "VCC" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "9" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_out line 
-                (at -12.7 -7.62 0) 
-                (length 2.54) 
-                (name "VDDA" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "8" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at -12.7 -10.16 0) 
-                (length 2.54) 
-                (name "EN" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "19" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at -12.7 -12.7 0) 
-                (length 2.54) 
-                (name "VCCX" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "16" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin output line 
-                (at -12.7 -15.24 0) 
-                (length 2.54) 
-                (name "PG" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "17" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at -12.7 -17.78 0) 
-                (length 2.54) 
-                (name "PFM" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "18" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin output line 
-                (at -12.7 -21.59 0) 
-                (length 2.54) 
-                (name "EXTCOMP" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "5" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at -12.7 -24.13 0) 
-                (length 2.54) 
-                (name "CNFG" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "3" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at -12.7 -26.67 0) 
-                (length 2.54) 
-                (name "RT" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "4" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at -1.27 -31.75 90) 
-                (length 2.54) 
-                (name "AGND" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "7" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at 1.27 -31.75 90) 
-                (length 2.54) 
-                (hide yes) 
-                (name "NC" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at 1.27 -31.75 90) 
-                (length 2.54) 
-                (name "PGND" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "10" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at 1.27 -31.75 90) 
-                (length 2.54) 
-                (hide yes) 
-                (name "NC" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "2" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at 1.27 -31.75 90) 
-                (length 2.54) 
-                (hide yes) 
-                (name "NC" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "22" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at 1.27 -31.75 90) 
-                (length 2.54) 
-                (hide yes) 
-                (name "NC" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "23" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at 1.27 -31.75 90) 
-                (length 2.54) 
-                (hide yes) 
-                (name "NC" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "24" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at 12.7 -2.54 180) 
-                (length 2.54) 
-                (name "CBOOT" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "15" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin output line 
-                (at 12.7 -5.08 180) 
-                (length 2.54) 
-                (name "HO" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "13" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_out line 
-                (at 12.7 -7.62 180) 
-                (length 2.54) 
-                (name "SW" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "14" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin output line 
-                (at 12.7 -10.16 180) 
-                (length 2.54) 
-                (name "LO" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "11" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at 12.7 -13.97 180) 
-                (length 2.54) 
-                (name "ISNS+" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "20" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at 12.7 -16.51 180) 
-                (length 2.54) 
-                (name "VOUT" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "21" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at 12.7 -24.13 180) 
-                (length 2.54) 
-                (name "FB" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "6" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))))) 
-        (embedded_fonts no)) 
-    (symbol "MP2459GJ-Z-MS" 
-        (exclude_from_sim no) 
-        (in_bom yes) 
-        (on_board yes) 
-        (property "Reference" "U" 
-            (at -7.62 6.35 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)))) 
-        (property "Value" "MP2459GJ-Z-MS" 
-            (at 2.54 6.35 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)))) 
-        (property "Footprint" "Package_TO_SOT_SMD:TSOT-23-6" 
-            (at 0 -22.86 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "Datasheet" "https://www.lcsc.com/datasheet/lcsc_datasheet_2504101957_MSKSEMI-MP2459GJ-Z-MS_C45367195.pdf" 
-            (at -0.254 -25.908 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "Description" "Monolithic, step-down, switch mode converter with a built-in power MOSFET" 
-            (at -0.508 -20.066 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "ki_keywords" "2A Buck DC/DC" 
-            (at 0 0 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "ki_fp_filters" "TSOT?23*" 
-            (at 0 0 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (symbol "MP2459GJ-Z-MS_0_1" 
-            (rectangle 
-                (start -7.62 5.08) 
-                (end 7.62 -5.08) 
-                (stroke 
-                    (width 0.254) 
-                    (type default)) 
-                (fill 
-                    (type background)))) 
-        (symbol "MP2459GJ-Z-MS_1_1" 
-            (pin power_in line 
-                (at -10.16 2.54 0) 
-                (length 2.54) 
-                (name "IN" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "5" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at -10.16 -2.54 0) 
-                (length 2.54) 
-                (name "EN" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "4" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at 0 -7.62 90) 
-                (length 2.54) 
-                (name "GND" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "2" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin output line 
-                (at 10.16 2.54 180) 
-                (length 2.54) 
-                (name "SW" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "6" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at 10.16 0 180) 
-                (length 2.54) 
-                (name "BST" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at 10.16 -2.54 180) 
-                (length 2.54) 
-                (name "FB" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "3" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))))) 
-        (embedded_fonts no)) 
-    (symbol "NMOS_Heatsink" 
-        (exclude_from_sim no) 
-        (in_bom yes) 
-        (on_board yes) 
-        (property "Reference" "Q" 
-            (at 0 0 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)))) 
-        (property "Value" "" 
-            (at 0 0 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)))) 
-        (property "Footprint" "" 
-            (at 0 0 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "Datasheet" "" 
-            (at 0 0 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (symbol "NMOS_Heatsink_0_1" 
-            (polyline 
-                (pts 
-                    (xy 2.794 10.795) 
-                    (xy 2.794 6.985)) 
-                (stroke 
-                    (width 0.254) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (polyline 
-                (pts 
-                    (xy 2.794 8.89) 
-                    (xy 0 8.89)) 
-                (stroke 
-                    (width 0) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (polyline 
-                (pts 
-                    (xy 3.302 11.176) 
-                    (xy 3.302 10.16)) 
-                (stroke 
-                    (width 0.254) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (polyline 
-                (pts 
-                    (xy 3.302 9.398) 
-                    (xy 3.302 8.382)) 
-                (stroke 
-                    (width 0.254) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (polyline 
-                (pts 
-                    (xy 3.302 7.62) 
-                    (xy 3.302 6.604)) 
-                (stroke 
-                    (width 0.254) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (polyline 
-                (pts 
-                    (xy 3.302 7.112) 
-                    (xy 5.842 7.112) 
-                    (xy 5.842 10.668) 
-                    (xy 3.302 10.668)) 
-                (stroke 
-                    (width 0) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (polyline 
-                (pts 
-                    (xy 3.556 8.89) 
-                    (xy 4.572 9.271) 
-                    (xy 4.572 8.509) 
-                    (xy 3.556 8.89)) 
-                (stroke 
-                    (width 0) 
-                    (type default)) 
-                (fill 
-                    (type outline))) 
-            (circle 
-                (center 4.191 8.89) 
-                (radius 2.794) 
-                (stroke 
-                    (width 0.254) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (polyline 
-                (pts 
-                    (xy 5.08 11.43) 
-                    (xy 5.08 10.668)) 
-                (stroke 
-                    (width 0) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (circle 
-                (center 5.08 10.668) 
-                (radius 0.254) 
-                (stroke 
-                    (width 0) 
-                    (type default)) 
-                (fill 
-                    (type outline))) 
-            (circle 
-                (center 5.08 7.112) 
-                (radius 0.254) 
-                (stroke 
-                    (width 0) 
-                    (type default)) 
-                (fill 
-                    (type outline))) 
-            (polyline 
-                (pts 
-                    (xy 5.08 6.35) 
-                    (xy 5.08 8.89) 
-                    (xy 3.302 8.89)) 
-                (stroke 
-                    (width 0) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (polyline 
-                (pts 
-                    (xy 5.461 9.271) 
-                    (xy 6.223 9.271)) 
-                (stroke 
-                    (width 0) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (polyline 
-                (pts 
-                    (xy 5.842 9.271) 
-                    (xy 5.461 8.636) 
-                    (xy 6.223 8.636) 
-                    (xy 5.842 9.271)) 
-                (stroke 
-                    (width 0) 
-                    (type default)) 
-                (fill 
-                    (type none)))) 
-        (symbol "NMOS_Heatsink_1_1" 
-            (pin input line 
-                (at -2.54 8.89 0) 
-                (length 2.54) 
-                (name "G" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at 5.08 13.97 270) 
-                (length 2.54) 
-                (name "D" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "2" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at 5.08 13.97 270) 
-                (length 2.54) 
-                (hide yes) 
-                (name "Heatsink" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "4" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at 5.08 3.81 90) 
-                (length 2.54) 
-                (name "S" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "3" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))))) 
-        (embedded_fonts no)) 
-    (symbol "RT9742GGJ5" 
-        (exclude_from_sim no) 
-        (in_bom yes) 
-        (on_board yes) 
-        (property "Reference" "U" 
-            (at 0 7.62 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)))) 
-        (property "Value" "RT9742GGJ5" 
-            (at 0 5.842 0) 
-            (effects 
-                (font 
-                    (size 1.016 1.016)))) 
-        (property "Footprint" "Package_TO_SOT_SMD:TSOT-23-5" 
-            (at 0 -15.494 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "Datasheet" "https://www.lcsc.com/datasheet/C250547.pdf" 
-            (at 0 -18.034 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "Description" "USB Positive Overvoltage Protection Controller with Internal PMOS FET and Overcurrent Protection, TSOP-5" 
-            (at 0 -12.7 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "ki_keywords" "overvoltage protection USB" 
-            (at 0 0 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "ki_fp_filters" "TSOP*1.65x3.05*P0.95*" 
-            (at 0 0 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (symbol "RT9742GGJ5_0_1" 
-            (rectangle 
-                (start -7.62 5.08) 
-                (end 7.62 -5.08) 
-                (stroke 
-                    (width 0.254) 
-                    (type default)) 
-                (fill 
-                    (type background)))) 
-        (symbol "RT9742GGJ5_1_1" 
-            (pin power_in line 
-                (at -10.16 2.54 0) 
-                (length 2.54) 
-                (name "IN" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin open_collector line 
-                (at -10.16 0 0) 
-                (length 2.54) 
-                (name "~{FLAG}" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "4" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at -10.16 -2.54 0) 
-                (length 2.54) 
-                (name "EN" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "3" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at 0 -7.62 90) 
-                (length 2.54) 
-                (name "GND" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "2" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_out line 
-                (at 10.16 2.54 180) 
-                (length 2.54) 
-                (name "OUT" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "5" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))))) 
-        (embedded_fonts no)) 
-    (symbol "R_CompactH" 
-        (pin_numbers 
-            (hide yes)) 
-        (pin_names 
-            (offset 0.254) 
-            (hide yes)) 
-        (exclude_from_sim no) 
-        (in_bom yes) 
-        (on_board yes) 
-        (property "Reference" "R" 
-            (at 1.8415 0.1905 0) 
-            (do_not_autoplace) 
-            (effects 
-                (font 
-                    (size 1.016 1.016)) 
-                (justify left bottom))) 
-        (property "Value" "R_CompactH" 
-            (at 0 0 0) 
-            (do_not_autoplace) 
-            (effects 
-                (font 
-                    (size 0.762 0.762)))) 
-        (property "Footprint" "" 
-            (at 0 0 90) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "Datasheet" "~" 
-            (at 0 0 90) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "Description" "Resistor, compact symbol" 
-            (at -0.1905 0.1905 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "ki_keywords" "R resistor" 
-            (at 0 0 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "ki_fp_filters" "R_*" 
-            (at 0 0 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (symbol "R_CompactH_0_1" 
-            (rectangle 
-                (start -1.778 -0.762) 
-                (end 1.778 0.762) 
-                (stroke 
-                    (width 0.2032) 
-                    (type default)) 
-                (fill 
-                    (type none)))) 
-        (symbol "R_CompactH_1_1" 
-            (pin passive line 
-                (at -2.54 0 0) 
-                (length 0.762) 
-                (name "~" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at 2.54 0 180) 
-                (length 0.762) 
-                (name "~" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "2" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))))) 
-        (embedded_fonts no)) 
-    (symbol "R_CompactV" 
-        (pin_numbers 
-            (hide yes)) 
-        (pin_names 
-            (offset 0.254) 
-            (hide yes)) 
-        (exclude_from_sim no) 
-        (in_bom yes) 
-        (on_board yes) 
-        (property "Reference" "R" 
-            (at -0.889 0 90) 
-            (do_not_autoplace) 
-            (effects 
-                (font 
-                    (size 1.016 1.016)) 
-                (justify bottom))) 
-        (property "Value" "R_CompactV" 
-            (at 0 0 90) 
-            (do_not_autoplace) 
-            (effects 
-                (font 
-                    (size 0.762 0.762)))) 
-        (property "Footprint" "" 
-            (at 0 0 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "Datasheet" "~" 
-            (at 0 0 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "Description" "Resistor, compact symbol" 
-            (at 0 0 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "ki_keywords" "R resistor" 
-            (at 0 0 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "ki_fp_filters" "R_*" 
-            (at 0 0 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (symbol "R_CompactV_0_1" 
-            (rectangle 
-                (start -0.762 1.778) 
-                (end 0.762 -1.778) 
-                (stroke 
-                    (width 0.2032) 
-                    (type default)) 
-                (fill 
-                    (type none)))) 
-        (symbol "R_CompactV_1_1" 
-            (pin passive line 
-                (at 0 2.54 270) 
-                (length 0.762) 
-                (name "~" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at 0 -2.54 90) 
-                (length 0.762) 
-                (name "~" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "2" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))))) 
-        (embedded_fonts no)) 
-    (symbol "TCAN1462V" 
-        (exclude_from_sim no) 
-        (in_bom yes) 
-        (on_board yes) 
-        (property "Reference" "U" 
-            (at 1.905 8.255 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (justify left))) 
-        (property "Value" "TCAN1462V" 
-            (at 1.905 6.35 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (justify left))) 
-        (property "Footprint" "Package_SO:SOIC-8_3.9x4.9mm_P1.27mm" 
-            (at 0 -18.034 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "Datasheet" "https://www.ti.com/lit/ds/symlink/tcan1462-q1.pdf" 
-            (at 0 -20.32 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "Description" "CAN FD Transceiver with Signal Improvement Capability (SIC)" 
-            (at 0 -15.24 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (symbol "TCAN1462V_1_1" 
-            (rectangle 
-                (start -7.62 5.08) 
-                (end 7.62 -5.08) 
-                (stroke 
-                    (width 0) 
-                    (type solid)) 
-                (fill 
-                    (type background))) 
-            (pin input line 
-                (at -10.16 2.54 0) 
-                (length 2.54) 
-                (name "RXD" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "4" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at -10.16 0 0) 
-                (length 2.54) 
-                (name "TXD" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at -10.16 -2.54 0) 
-                (length 2.54) 
-                (name "STB" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "8" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at -1.27 7.62 270) 
-                (length 2.54) 
-                (name "VIO" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "5" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at 0 -7.62 90) 
-                (length 2.54) 
-                (name "GND" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "2" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at 0 -7.62 90) 
-                (length 2.54) 
-                (hide yes) 
-                (name "EP" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "9" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at 1.27 7.62 270) 
-                (length 2.54) 
-                (name "VCC" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "3" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at 10.16 1.27 180) 
-                (length 2.54) 
-                (name "CANH" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "7" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at 10.16 -1.27 180) 
-                (length 2.54) 
-                (name "CANL" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "6" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))))) 
-        (embedded_fonts no)) 
-    (symbol "TMC5160A-TA" 
-        (exclude_from_sim no) 
-        (in_bom yes) 
-        (on_board yes) 
-        (property "Reference" "U" 
-            (at -7.366 45.212 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (justify right))) 
-        (property "Value" "TMC5160A-TA" 
-            (at 31.75 48.768 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (justify left))) 
-        (property "Footprint" "Package_QFP:TQFP-48-1EP_7x7mm_P0.5mm_EP5x5mm_ThermalVias" 
-            (at 0 -50.8 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "Datasheet" "https://www.trinamic.com/fileadmin/assets/Products/ICs_Documents/TMC5160A_Datasheet_Rev1.14.pdf" 
-            (at 0.762 -53.34 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "Description" "20A Driver for two-phase bipolar stepper motor, SPI, UART, TQFP-48" 
-            (at -0.508 -48.26 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "ki_keywords" "stepper motor driver trinamic" 
-            (at 0 0 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "ki_fp_filters" "TQFP*1EP*7x7mm*P0.5mm*" 
-            (at 0 0 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (symbol "TMC5160A-TA_1_0" 
-            (rectangle 
-                (start -15.24 44.45) 
-                (end 15.24 -44.45) 
-                (stroke 
-                    (width 0.254) 
-                    (type default)) 
-                (fill 
-                    (type background)))) 
-        (symbol "TMC5160A-TA_1_1" 
-            (pin passive line 
-                (at -17.78 41.91 0) 
-                (length 2.54) 
-                (name "VCP" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "34" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at -17.78 39.37 0) 
-                (length 2.54) 
-                (name "CPO" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "31" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at -17.78 34.29 0) 
-                (length 2.54) 
-                (name "CPI" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "32" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at -17.78 30.48 0) 
-                (length 2.54) 
-                (name "12VOUT" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "3" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_out line 
-                (at -17.78 27.94 0) 
-                (length 2.54) 
-                (name "5VOUT" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "5" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at -17.78 22.86 0) 
-                (length 2.54) 
-                (name "VCC" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "29" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at -17.78 11.43 0) 
-                (length 2.54) 
-                (name "CLK" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "12" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at -17.78 6.35 0) 
-                (length 2.54) 
-                (name "~{CS}/CFG3" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "13" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at -17.78 3.81 0) 
-                (length 2.54) 
-                (name "SCK/CFG2" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "14" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at -17.78 1.27 0) 
-                (length 2.54) 
-                (name "SDI/CFG1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "15" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at -17.78 -1.27 0) 
-                (length 2.54) 
-                (name "SDO/CFG0" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "16" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at -17.78 -6.35 0) 
-                (length 2.54) 
-                (name "REFL/STEP" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "17" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at -17.78 -8.89 0) 
-                (length 2.54) 
-                (name "REFR/DIR" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "18" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at -17.78 -13.97 0) 
-                (length 2.54) 
-                (name "ENCN/DCO/CFG6" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "25" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at -17.78 -16.51 0) 
-                (length 2.54) 
-                (name "ENCA/DCIN/CFG5" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "24" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at -17.78 -19.05 0) 
-                (length 2.54) 
-                (name "ENCB/DCEN/CFG4" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "23" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at -17.78 -24.13 0) 
-                (length 2.54) 
-                (name "~{DRV_EN}" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "28" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at -17.78 -29.21 0) 
-                (length 2.54) 
-                (name "SWN/DIAG0" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "26" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at -17.78 -31.75 0) 
-                (length 2.54) 
-                (name "SWP/DIAG1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "27" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at -17.78 -36.83 0) 
-                (length 2.54) 
-                (name "SD_MODE" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "21" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at -17.78 -39.37 0) 
-                (length 2.54) 
-                (name "SPI_MODE" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "22" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at -17.78 -41.91 0) 
-                (length 2.54) 
-                (name "TST_MODE" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "11" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at -2.54 46.99 270) 
-                (length 2.54) 
-                (name "VS" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "33" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at -2.54 -46.99 90) 
-                (length 2.54) 
-                (name "GNDD" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "19" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at -2.54 -46.99 90) 
-                (length 2.54) 
-                (hide yes) 
-                (name "GNDD" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "30" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at 0 46.99 270) 
-                (length 2.54) 
-                (name "VSA" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "4" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at 0 -46.99 90) 
-                (length 2.54) 
-                (name "GNDA" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "6" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at 2.54 46.99 270) 
-                (length 2.54) 
-                (name "VCC_IO" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "20" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at 2.54 -46.99 90) 
-                (length 2.54) 
-                (name "EP" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "49" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin output line 
-                (at 17.78 41.91 180) 
-                (length 2.54) 
-                (name "HA1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "41" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin output line 
-                (at 17.78 39.37 180) 
-                (length 2.54) 
-                (name "LA1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "39" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin output line 
-                (at 17.78 36.83 180) 
-                (length 2.54) 
-                (name "HA2" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "36" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin output line 
-                (at 17.78 34.29 180) 
-                (length 2.54) 
-                (name "LA2" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "38" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at 17.78 24.13 180) 
-                (length 2.54) 
-                (name "SRAH" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "8" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at 17.78 21.59 180) 
-                (length 2.54) 
-                (name "SRAL" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "7" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at 17.78 17.78 180) 
-                (length 2.54) 
-                (name "CA1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "42" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at 17.78 12.7 180) 
-                (length 2.54) 
-                (name "BMA1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "40" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at 17.78 8.89 180) 
-                (length 2.54) 
-                (name "CA2" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "35" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at 17.78 3.81 180) 
-                (length 2.54) 
-                (name "BMA2" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "37" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at 17.78 -3.81 180) 
-                (length 2.54) 
-                (name "CB1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "2" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at 17.78 -8.89 180) 
-                (length 2.54) 
-                (name "BMB1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "48" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at 17.78 -12.7 180) 
-                (length 2.54) 
-                (name "CB2" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "43" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at 17.78 -17.78 180) 
-                (length 2.54) 
-                (name "BMB2" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "45" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin output line 
-                (at 17.78 -21.59 180) 
-                (length 2.54) 
-                (name "HB1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin output line 
-                (at 17.78 -24.13 180) 
-                (length 2.54) 
-                (name "LB1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "47" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin output line 
-                (at 17.78 -26.67 180) 
-                (length 2.54) 
-                (name "HB2" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "44" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin output line 
-                (at 17.78 -29.21 180) 
-                (length 2.54) 
-                (name "LB2" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "46" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at 17.78 -39.37 180) 
-                (length 2.54) 
-                (name "SRBH" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "9" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at 17.78 -41.91 180) 
-                (length 2.54) 
-                (name "SRBL" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "10" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))))) 
-        (embedded_fonts no)) 
-    (symbol "TPS1H200A" 
-        (pin_names 
-            (offset 0.254)) 
-        (exclude_from_sim no) 
-        (in_bom yes) 
-        (on_board yes) 
-        (property "Reference" "U" 
-            (at 0 12.446 0) 
-            (effects 
-                (font 
-                    (size 1.524 1.524)))) 
-        (property "Value" "TPS1H200A" 
-            (at -0.254 10.16 0) 
-            (effects 
-                (font 
-                    (size 1.524 1.524)))) 
-        (property "Footprint" "Bluesat:DGN0008D_N" 
-            (at 0.508 -19.304 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27) 
-                    (italic yes)) 
-                (hide yes))) 
-        (property "Datasheet" "https://www.ti.com/lit/gpn/tps1h200a-q1" 
-            (at 0.254 -16.764 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27) 
-                    (italic yes)) 
-                (hide yes))) 
-        (property "Description" "40-V 200-m? Single-Channel Smart High-Side Switch" 
-            (at 0 -14.224 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "ki_locked" "" 
-            (at 0 0 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)))) 
-        (property "ki_keywords" "TPS1H200AQDGNRQ1" 
-            (at 0 0 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "ki_fp_filters" "DGN0008D_N DGN0008D_M DGN0008D_L" 
-            (at 0 0 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (symbol "TPS1H200A_0_1" 
-            (pin input line 
-                (at -11.43 6.35 0) 
-                (length 2.54) 
-                (name "IN" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at -11.43 3.81 0) 
-                (length 2.54) 
-                (name "VS" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "8" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at -11.43 0 0) 
-                (length 2.54) 
-                (name "DIAG_EN" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "2" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin open_collector line 
-                (at -11.43 -2.54 0) 
-                (length 2.54) 
-                (name "FAULT_N" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "3" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at -11.43 -6.35 0) 
-                (length 2.54) 
-                (name "CL" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "4" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at 0 -11.43 90) 
-                (length 2.54) 
-                (name "GND" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "6" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at 11.43 6.35 180) 
-                (length 2.54) 
-                (name "OUT" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "7" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 11.43 -6.35 180) 
-                (length 2.54) 
-                (name "DELAY" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "5" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))))) 
-        (symbol "TPS1H200A_1_1" 
-            (rectangle 
-                (start -8.89 8.89) 
-                (end 8.89 -8.89) 
-                (stroke 
-                    (width 0) 
-                    (type solid)) 
-                (fill 
-                    (type background))) 
-            (pin passive line 
-                (at 0 -11.43 90) 
-                (length 2.54) 
-                (hide yes) 
-                (name "PAD" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "9" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))))) 
-        (embedded_fonts no)) 
-    (symbol "TPS61175" 
-        (exclude_from_sim no) 
-        (in_bom yes) 
-        (on_board yes) 
-        (property "Reference" "U" 
-            (at 0 8.89 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)))) 
-        (property "Value" "" 
-            (at 0 0 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)))) 
-        (property "Footprint" "Bluesat:PowerPAD_HTSSOP-14_4.4x5.0-0.65-EP" 
-            (at 0 12.954 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "Datasheet" "https://www.ti.com/lit/ds/symlink/tps61175.pdf" 
-            (at 0 10.668 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "Description" "3-A High-Voltage Boost Converter With Soft Start and Programmable Switching Frequency" 
-            (at 0 15.24 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (symbol "TPS61175_1_1" 
-            (rectangle 
-                (start -10.16 7.62) 
-                (end 10.16 -7.62) 
-                (stroke 
-                    (width 0) 
-                    (type solid)) 
-                (fill 
-                    (type background))) 
-            (pin power_in line 
-                (at -12.7 5.08 0) 
-                (length 2.54) 
-                (name "VIN" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "3" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at -12.7 2.54 0) 
-                (length 2.54) 
-                (name "EN" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "4" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at -12.7 0 0) 
-                (length 2.54) 
-                (name "FREQ" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "10" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at -12.7 -2.54 0) 
-                (length 2.54) 
-                (name "SS" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "5" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at -12.7 -5.08 0) 
-                (length 2.54) 
-                (name "SYNC" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "6" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at -1.27 -10.16 90) 
-                (length 2.54) 
-                (hide yes) 
-                (name "NC" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "11" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at -1.27 -10.16 90) 
-                (length 2.54) 
-                (hide yes) 
-                (name "EP" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "15" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at -1.27 -10.16 90) 
-                (length 2.54) 
-                (name "AGND" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "7" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at 1.27 -10.16 90) 
-                (length 2.54) 
-                (name "PGND" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "12" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at 1.27 -10.16 90) 
-                (length 2.54) 
-                (hide yes) 
-                (name "PGND" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "13" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at 1.27 -10.16 90) 
-                (length 2.54) 
-                (hide yes) 
-                (name "PGND" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "14" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_out line 
-                (at 12.7 5.08 180) 
-                (length 2.54) 
-                (name "SW" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at 12.7 5.08 180) 
-                (length 2.54) 
-                (hide yes) 
-                (name "SW" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "2" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at 12.7 0 180) 
-                (length 2.54) 
-                (name "FB" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "9" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at 12.7 -2.54 180) 
-                (length 2.54) 
-                (name "COMP" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "8" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))))) 
-        (embedded_fonts no)) 
-    (symbol "USB5744" 
-        (pin_names 
-            (offset 0.254)) 
-        (exclude_from_sim no) 
-        (in_bom yes) 
-        (on_board yes) 
-        (property "Reference" "U" 
-            (at 0.254 3.556 0) 
-            (effects 
-                (font 
-                    (size 1.524 1.524)))) 
-        (property "Value" "USB5744" 
-            (at 1.016 1.27 0) 
-            (effects 
-                (font 
-                    (size 1.524 1.524)))) 
-        (property "Footprint" "Bluesat:VQFN56_2G_MCH" 
-            (at -0.254 -80.264 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27) 
-                    (italic yes)) 
-                (hide yes))) 
-        (property "Datasheet" "https://ww1.microchip.com/downloads/aemDocuments/documents/UNG/ProductDocuments/DataSheets/USB5744-Data-Sheet-DS00001855.pdf" 
-            (at 0 -82.296 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27) 
-                    (italic yes)) 
-                (hide yes))) 
-        (property "Description" "USB v3.2 Hub (5 Gbps)" 
-            (at 0 -77.978 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "ki_locked" "" 
-            (at 0 0 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)))) 
-        (property "ki_keywords" "USB5744/2GX01" 
-            (at 0 0 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "ki_fp_filters" "VQFN56_2G_MCH VQFN56_2G_MCH-M VQFN56_2G_MCH-L" 
-            (at 0 0 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (symbol "USB5744_1_1" 
-            (rectangle 
-                (start -25.4 0) 
-                (end 25.4 -73.66) 
-                (stroke 
-                    (width 0) 
-                    (type solid)) 
-                (fill 
-                    (type background))) 
-            (pin input line 
-                (at -27.94 -2.54 0) 
-                (length 2.54) 
-                (name "PRT_CTL1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "36" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at -27.94 -5.08 0) 
-                (length 2.54) 
-                (name "PRT_CTL2" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "35" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at -27.94 -7.62 0) 
-                (length 2.54) 
-                (name "PRT_CTL3" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "34" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at -27.94 -10.16 0) 
-                (length 2.54) 
-                (name "PRT_CTL4/GANG_PWR" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "32" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin unspecified line 
-                (at -27.94 -15.24 0) 
-                (length 2.54) 
-                (name "RBIAS" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "56" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin unspecified line 
-                (at -27.94 -17.78 0) 
-                (length 2.54) 
-                (name "ATEST" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "52" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at -27.94 -20.32 0) 
-                (length 2.54) 
-                (name "SPI_CE_N/CFG_NON_REM" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "41" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at -27.94 -22.86 0) 
-                (length 2.54) 
-                (name "SPI_DI/CFG_BC_EN" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "40" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at -27.94 -27.94 0) 
-                (length 2.54) 
-                (name "XTALI/CLK_IN" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "54" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin output line 
-                (at -27.94 -30.48 0) 
-                (length 2.54) 
-                (name "XTALO" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "53" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at -27.94 -35.56 0) 
-                (length 2.54) 
-                (name "VBUS_DET" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "37" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at -27.94 -40.64 0) 
-                (length 2.54) 
-                (name "SPI_CLK/SMCLK" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "38" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at -27.94 -43.18 0) 
-                (length 2.54) 
-                (name "SPI_DO/SMDAT" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "39" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at -27.94 -48.26 0) 
-                (length 2.54) 
-                (name "USB2UP_DM" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "46" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at -27.94 -50.8 0) 
-                (length 2.54) 
-                (name "USB2UP_DP" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "45" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at -27.94 -55.88 0) 
-                (length 2.54) 
-                (name "USB3UP_RXDM" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "51" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at -27.94 -58.42 0) 
-                (length 2.54) 
-                (name "USB3UP_RXDP" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "50" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at -27.94 -60.96 0) 
-                (length 2.54) 
-                (name "USB3UP_TXDM" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "48" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at -27.94 -63.5 0) 
-                (length 2.54) 
-                (name "USB3UP_TXDP" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "47" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at -27.94 -71.12 0) 
-                (length 2.54) 
-                (name "RESET_N" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "42" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 27.94 -2.54 180) 
-                (length 2.54) 
-                (name "USB2DN_DM1/PRT_DIS_M1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "2" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 27.94 -5.08 180) 
-                (length 2.54) 
-                (name "USB2DN_DP1/PRT_DIS_P1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 27.94 -8.89 180) 
-                (length 2.54) 
-                (name "USB2DN_DM2/PRT_DIS_M2" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "9" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 27.94 -11.43 180) 
-                (length 2.54) 
-                (name "USB2DN_DP2/PRT_DIS_P2" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "8" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 27.94 -15.24 180) 
-                (length 2.54) 
-                (name "USB2DN_DM3/PRT_DIS_M3" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "18" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 27.94 -17.78 180) 
-                (length 2.54) 
-                (name "USB2DN_DP3/PRT_DIS_P3" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "17" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 27.94 -21.59 180) 
-                (length 2.54) 
-                (name "USB2DN_DM4/PRT_DIS_M4" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "25" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 27.94 -24.13 180) 
-                (length 2.54) 
-                (name "USB2DN_DP4/PRT_DIS_P4" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "24" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 27.94 -29.21 180) 
-                (length 2.54) 
-                (name "USB3DN_RXDM1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "7" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 27.94 -31.75 180) 
-                (length 2.54) 
-                (name "USB3DN_RXDP1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "6" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 27.94 -34.29 180) 
-                (length 2.54) 
-                (name "USB3DN_TXDM1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "4" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 27.94 -36.83 180) 
-                (length 2.54) 
-                (name "USB3DN_TXDP1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "3" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 27.94 -40.64 180) 
-                (length 2.54) 
-                (name "USB3DN_RXDM2" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "14" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 27.94 -43.18 180) 
-                (length 2.54) 
-                (name "USB3DN_RXDP2" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "13" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 27.94 -45.72 180) 
-                (length 2.54) 
-                (name "USB3DN_TXDM2" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "11" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 27.94 -48.26 180) 
-                (length 2.54) 
-                (name "USB3DN_TXDP2" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "10" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 27.94 -52.07 180) 
-                (length 2.54) 
-                (name "USB3DN_RXDM3" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "23" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 27.94 -54.61 180) 
-                (length 2.54) 
-                (name "USB3DN_RXDP3" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "22" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 27.94 -57.15 180) 
-                (length 2.54) 
-                (name "USB3DN_TXDM3" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "20" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 27.94 -59.69 180) 
-                (length 2.54) 
-                (name "USB3DN_TXDP3" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "19" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 27.94 -63.5 180) 
-                (length 2.54) 
-                (name "USB3DN_RXDM4" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "30" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 27.94 -66.04 180) 
-                (length 2.54) 
-                (name "USB3DN_RXDP4" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "29" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 27.94 -68.58 180) 
-                (length 2.54) 
-                (name "USB3DN_TXDM4" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "27" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 27.94 -71.12 180) 
-                (length 2.54) 
-                (name "USB3DN_TXDP4" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "26" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))))) 
-        (symbol "USB5744_2_1" 
-            (rectangle 
-                (start -10.16 0) 
-                (end 10.16 -22.86) 
-                (stroke 
-                    (width 0) 
-                    (type solid)) 
-                (fill 
-                    (type background))) 
-            (pin power_in line 
-                (at -12.7 -2.54 0) 
-                (length 2.54) 
-                (name "VDD12" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "5" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at -12.7 -5.08 0) 
-                (length 2.54) 
-                (name "VDD12" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "12" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at -12.7 -7.62 0) 
-                (length 2.54) 
-                (name "VDD12" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "15" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at -12.7 -10.16 0) 
-                (length 2.54) 
-                (name "VDD12" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "21" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at -12.7 -12.7 0) 
-                (length 2.54) 
-                (name "VDD12" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "28" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at -12.7 -15.24 0) 
-                (length 2.54) 
-                (name "VDD12" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "33" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at -12.7 -17.78 0) 
-                (length 2.54) 
-                (name "VDD12" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "43" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at -12.7 -20.32 0) 
-                (length 2.54) 
-                (name "VDD12" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "49" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at 0 -25.4 90) 
-                (length 2.54) 
-                (name "VSS" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "57" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at 12.7 -2.54 180) 
-                (length 2.54) 
-                (name "VDD33" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "16" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at 12.7 -5.08 180) 
-                (length 2.54) 
-                (name "VDD33" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "31" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at 12.7 -7.62 180) 
-                (length 2.54) 
-                (name "VDD33" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "44" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at 12.7 -10.16 180) 
-                (length 2.54) 
-                (name "VDD33" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "55" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))))) 
-        (embedded_fonts no)) 
-    (symbol "USB7216C" 
-        (pin_names 
-            (offset 0.254)) 
-        (exclude_from_sim no) 
-        (in_bom yes) 
-        (on_board yes) 
-        (property "Reference" "U" 
-            (at 0 6.096 0) 
-            (effects 
-                (font 
-                    (size 1.524 1.524)))) 
-        (property "Value" "USB7216CT/KDX" 
-            (at 0.508 3.556 0) 
-            (effects 
-                (font 
-                    (size 1.524 1.524)))) 
-        (property "Footprint" "Bluesat:VQFN100_KDX_MCH" 
-            (at 0 9.398 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27) 
-                    (italic yes)) 
-                (hide yes))) 
-        (property "Datasheet" "https://au.mouser.com/datasheet/3/282/1/USB7216C-Data-Sheet-DS00003851.pdf" 
-            (at 0 6.858 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27) 
-                    (italic yes)) 
-                (hide yes))) 
-        (property "Description" "6-port USB v3.2 Gen 2 Hub (20 Gbps)" 
-            (at 0 11.938 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "ki_locked" "" 
-            (at 0 0 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)))) 
-        (property "ki_keywords" "USB7216C-I/KDX" 
-            (at 0 0 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "ki_fp_filters" "VQFN100_KDX_MCH VQFN100_KDX_MCH-M VQFN100_KDX_MCH-L" 
-            (at 0 0 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (symbol "USB7216C_1_1" 
-            (rectangle 
-                (start -25.4 0) 
-                (end 25.4 -107.95) 
-                (stroke 
-                    (width 0) 
-                    (type solid)) 
-                (fill 
-                    (type background))) 
-            (pin input line 
-                (at -27.94 -2.54 0) 
-                (length 2.54) 
-                (name "CFG_STRAP1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "21" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at -27.94 -5.08 0) 
-                (length 2.54) 
-                (name "CFG_STRAP2" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "22" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at -27.94 -7.62 0) 
-                (length 2.54) 
-                (name "CFG_STRAP3" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "23" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at -27.94 -12.7 0) 
-                (length 2.54) 
-                (name "RBIAS" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "100" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin unspecified line 
-                (at -27.94 -15.24 0) 
-                (length 2.54) 
-                (name "ATEST" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "96" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at -27.94 -20.32 0) 
-                (length 2.54) 
-                (name "SPI_CLK/PF21" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "68" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at -27.94 -24.13 0) 
-                (length 2.54) 
-                (name "SPI_D0/CFG_BC_EN/PF22" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "70" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at -27.94 -26.67 0) 
-                (length 2.54) 
-                (name "SPI_D1/PF23" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "71" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at -27.94 -29.21 0) 
-                (length 2.54) 
-                (name "SPI_D2/PF24" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "72" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at -27.94 -31.75 0) 
-                (length 2.54) 
-                (name "SPI_D3/PF25" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "73" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at -27.94 -35.56 0) 
-                (length 2.54) 
-                (name "SPI_CE_N/CFG_NON_REM/PF20" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "69" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at -27.94 -38.1 0) 
-                (length 2.54) 
-                (name "TESTEN" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "24" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at -27.94 -49.53 0) 
-                (length 2.54) 
-                (name "TEST1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "63" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at -27.94 -52.07 0) 
-                (length 2.54) 
-                (name "TEST2" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "64" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at -27.94 -54.61 0) 
-                (length 2.54) 
-                (name "TEST3" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "65" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at -27.94 -59.69 0) 
-                (length 2.54) 
-                (name "USB2UP_DM" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "90" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at -27.94 -62.23 0) 
-                (length 2.54) 
-                (name "USB2UP_DP" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "89" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at -27.94 -66.04 0) 
-                (length 2.54) 
-                (name "USB2DN_DM1/PRT_DIS_M1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "6" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at -27.94 -68.58 0) 
-                (length 2.54) 
-                (name "USB2DN_DP1/PRT_DIS_P1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "5" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at -27.94 -72.39 0) 
-                (length 2.54) 
-                (name "USB2DN_DM2/PRT_DIS_M2" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "28" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at -27.94 -74.93 0) 
-                (length 2.54) 
-                (name "USB2DN_DP2/PRT_DIS_P2" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "27" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at -27.94 -78.74 0) 
-                (length 2.54) 
-                (name "USB2DN_DM3/PRT_DIS_M3" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "35" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at -27.94 -81.28 0) 
-                (length 2.54) 
-                (name "USB2DN_DP3/PRT_DIS_P3" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "34" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at -27.94 -85.09 0) 
-                (length 2.54) 
-                (name "USB2DN_DM4/PRT_DIS_M4" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "82" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at -27.94 -87.63 0) 
-                (length 2.54) 
-                (name "USB2DN_DP4/PRT_DIS_P4" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "81" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at -27.94 -91.44 0) 
-                (length 2.54) 
-                (name "USB2DN_DM5/PRT_DIS_M5" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "15" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at -27.94 -93.98 0) 
-                (length 2.54) 
-                (name "USB2DN_DP5/PRT_DIS_P5" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "14" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at -27.94 -97.79 0) 
-                (length 2.54) 
-                (name "USB2DN_DM6/PRT_DIS_M6" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "41" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at -27.94 -100.33 0) 
-                (length 2.54) 
-                (name "USB2DN_DP6/PRT_DIS_P6" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "42" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at -27.94 -105.41 0) 
-                (length 2.54) 
-                (name "RESET_N" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at 27.94 -2.54 180) 
-                (length 2.54) 
-                (name "XTALI/CLK_IN" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "98" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin output line 
-                (at 27.94 -5.08 180) 
-                (length 2.54) 
-                (name "XTALO" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "97" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 27.94 -10.16 180) 
-                (length 2.54) 
-                (name "DP1_CC1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "12" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 27.94 -12.7 180) 
-                (length 2.54) 
-                (name "DP1_CC2" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "13" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin unspecified line 
-                (at 27.94 -15.24 180) 
-                (length 2.54) 
-                (name "DP1_VBUS_MON" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "4" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 27.94 -17.78 180) 
-                (length 2.54) 
-                (name "VBUS_MON_UP" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "80" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 27.94 -27.94 180) 
-                (length 2.54) 
-                (name "DP1_VCONN2/PF3" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "44" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 27.94 -30.48 180) 
-                (length 2.54) 
-                (name "DP1_VCONN1/PF4" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "45" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 27.94 -33.02 180) 
-                (length 2.54) 
-                (name "DP1_DISCHARGE/PF5" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "46" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 27.94 -35.56 180) 
-                (length 2.54) 
-                (name "GPIO70/PF6" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "47" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 27.94 -38.1 180) 
-                (length 2.54) 
-                (name "GPIO71/PF7" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "48" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 27.94 -40.64 180) 
-                (length 2.54) 
-                (name "GPIO72/PF8" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "49" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 27.94 -43.18 180) 
-                (length 2.54) 
-                (name "GPIO73/PF9" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "50" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 27.94 -45.72 180) 
-                (length 2.54) 
-                (name "PRT_CTL2_U3/PF10" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "51" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 27.94 -48.26 180) 
-                (length 2.54) 
-                (name "PRT_CTL3_U3/PF11" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "52" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 27.94 -50.8 180) 
-                (length 2.54) 
-                (name "PRT_CTL4_U3/PF12" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "54" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 27.94 -53.34 180) 
-                (length 2.54) 
-                (name "PRT_CTL4/PF13" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "56" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 27.94 -55.88 180) 
-                (length 2.54) 
-                (name "PRT_CTL3/PF14" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "57" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 27.94 -58.42 180) 
-                (length 2.54) 
-                (name "PRT_CTL2/PF15" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "58" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 27.94 -60.96 180) 
-                (length 2.54) 
-                (name "PRT_CTL5/PF16" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "59" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 27.94 -63.5 180) 
-                (length 2.54) 
-                (name "PRT_CTL1/PF17" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "60" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 27.94 -66.04 180) 
-                (length 2.54) 
-                (name "ALERT0/PF18" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "61" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 27.94 -68.58 180) 
-                (length 2.54) 
-                (name "PF19" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "66" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 27.94 -71.12 180) 
-                (length 2.54) 
-                (name "SLV_I2C_CLK/PF26" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "75" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 27.94 -73.66 180) 
-                (length 2.54) 
-                (name "SLV_I2C_DATA/PF27" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "76" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 27.94 -76.2 180) 
-                (length 2.54) 
-                (name "PRT_CTL6/PF28" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "77" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 27.94 -78.74 180) 
-                (length 2.54) 
-                (name "PF29" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "74" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 27.94 -81.28 180) 
-                (length 2.54) 
-                (name "MSTR_I2C_CLK/PF30" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "2" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 27.94 -83.82 180) 
-                (length 2.54) 
-                (name "MSTR_I2C_DATA/PF31" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "3" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))))) 
-        (symbol "USB7216C_2_1" 
-            (rectangle 
-                (start -10.16 0) 
-                (end 10.16 -69.85) 
-                (stroke 
-                    (width 0) 
-                    (type solid)) 
-                (fill 
-                    (type background))) 
-            (pin bidirectional line 
-                (at 12.7 -2.54 180) 
-                (length 2.54) 
-                (name "USB3UP_RXDM" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "95" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 12.7 -5.08 180) 
-                (length 2.54) 
-                (name "USB3UP_RXDP" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "94" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 12.7 -7.62 180) 
-                (length 2.54) 
-                (name "USB3UP_TXDM" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "92" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 12.7 -10.16 180) 
-                (length 2.54) 
-                (name "USB3UP_TXDP" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "91" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 12.7 -13.97 180) 
-                (length 2.54) 
-                (name "USB3DN_RXDM1A" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "11" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 12.7 -16.51 180) 
-                (length 2.54) 
-                (name "USB3DN_RXDP1A" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "10" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 12.7 -19.05 180) 
-                (length 2.54) 
-                (name "USB3DN_TXDM1A" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "8" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 12.7 -21.59 180) 
-                (length 2.54) 
-                (name "USB3DN_TXDP1A" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "7" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 12.7 -25.4 180) 
-                (length 2.54) 
-                (name "USB3DN_RXDM1B" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "20" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 12.7 -27.94 180) 
-                (length 2.54) 
-                (name "USB3DN_RXDP1B" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "19" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 12.7 -30.48 180) 
-                (length 2.54) 
-                (name "USB3DN_TXDM1B" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "17" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 12.7 -33.02 180) 
-                (length 2.54) 
-                (name "USB3DN_TXDP1B" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "16" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 12.7 -36.83 180) 
-                (length 2.54) 
-                (name "USB3DN_RXDM2" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "33" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 12.7 -39.37 180) 
-                (length 2.54) 
-                (name "USB3DN_RXDP2" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "32" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 12.7 -41.91 180) 
-                (length 2.54) 
-                (name "USB3DN_TXDM2" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "30" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 12.7 -44.45 180) 
-                (length 2.54) 
-                (name "USB3DN_TXDP2" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "29" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 12.7 -48.26 180) 
-                (length 2.54) 
-                (name "USB3DN_RXDM3" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "40" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 12.7 -50.8 180) 
-                (length 2.54) 
-                (name "USB3DN_RXDP3" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "39" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 12.7 -53.34 180) 
-                (length 2.54) 
-                (name "USB3DN_TXDM3" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "37" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 12.7 -55.88 180) 
-                (length 2.54) 
-                (name "USB3DN_TXDP3" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "36" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 12.7 -59.69 180) 
-                (length 2.54) 
-                (name "USB3DN_RXDM4" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "87" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 12.7 -62.23 180) 
-                (length 2.54) 
-                (name "USB3DN_RXDP4" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "86" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 12.7 -64.77 180) 
-                (length 2.54) 
-                (name "USB3DN_TXDM4" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "84" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 12.7 -67.31 180) 
-                (length 2.54) 
-                (name "USB3DN_TXDP4" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "83" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))))) 
-        (symbol "USB7216C_3_1" 
-            (rectangle 
-                (start -10.16 0) 
-                (end 10.16 -25.4) 
-                (stroke 
-                    (width 0) 
-                    (type solid)) 
-                (fill 
-                    (type background))) 
-            (pin power_in line 
-                (at -12.7 -2.54 0) 
-                (length 2.54) 
-                (name "VCORE" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "9" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at -12.7 -5.08 0) 
-                (length 2.54) 
-                (name "VCORE" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "18" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at -12.7 -7.62 0) 
-                (length 2.54) 
-                (name "VCORE" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "25" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at -12.7 -10.16 0) 
-                (length 2.54) 
-                (name "VCORE" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "31" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at -12.7 -12.7 0) 
-                (length 2.54) 
-                (name "VCORE" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "38" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at -12.7 -15.24 0) 
-                (length 2.54) 
-                (name "VCORE" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "55" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at -12.7 -17.78 0) 
-                (length 2.54) 
-                (name "VCORE" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "78" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at -12.7 -20.32 0) 
-                (length 2.54) 
-                (name "VCORE" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "85" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at -12.7 -22.86 0) 
-                (length 2.54) 
-                (name "VCORE" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "93" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at 0 -27.94 90) 
-                (length 2.54) 
-                (name "VSS" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "101" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at 12.7 -2.54 180) 
-                (length 2.54) 
-                (name "VDD33" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "26" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at 12.7 -5.08 180) 
-                (length 2.54) 
-                (name "VDD33" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "43" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at 12.7 -7.62 180) 
-                (length 2.54) 
-                (name "VDD33" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "53" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at 12.7 -10.16 180) 
-                (length 2.54) 
-                (name "VDD33" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "62" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at 12.7 -12.7 180) 
-                (length 2.54) 
-                (name "VDD33" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "67" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at 12.7 -15.24 180) 
-                (length 2.54) 
-                (name "VDD33" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "79" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at 12.7 -17.78 180) 
-                (length 2.54) 
-                (name "VDD33" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "88" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at 12.7 -20.32 180) 
-                (length 2.54) 
-                (name "VDD33" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "99" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))))) 
-        (embedded_fonts no)) 
-    (symbol "USB_C_Receptacle_USB2.0_14P" 
-        (pin_names 
-            (offset 1.016)) 
-        (exclude_from_sim no) 
-        (in_bom yes) 
-        (on_board yes) 
-        (property "Reference" "J**" 
-            (at -0.635 19.05 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)))) 
-        (property "Value" "USB_C_Receptacle_USB2.0_14P" 
-            (at -0.635 16.51 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)))) 
-        (property "Footprint" "Bluesat:USB_C_Receptacle_USB2.0_14P" 
-            (at 0 23.368 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "Datasheet" "https://www.lcsc.com/datasheet/C2765186.pdf" 
-            (at 2.54 -20.32 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "Description" "Type C USB2.0 Receptacle" 
-            (at 0 -18.288 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "ki_keywords" "16-Pin, USB-C, Type C, USB 2.0, 0.8mm PCB, SMD, 5A, Paste in hole" 
-            (at 0 0 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "ki_fp_filters" "Socket_GCT:USB4105_pasteInHole*" 
-            (at 0 0 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (symbol "USB_C_Receptacle_USB2.0_14P_0_1" 
-            (rectangle 
-                (start -7.62 12.7) 
-                (end 6.35 -15.24) 
-                (stroke 
-                    (width 0) 
-                    (type default)) 
-                (fill 
-                    (type background))) 
-            (polyline 
-                (pts 
-                    (xy -6.096 1.905) 
-                    (xy -6.096 -1.905)) 
-                (stroke 
-                    (width 0) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (polyline 
-                (pts 
-                    (xy -5.334 -1.905) 
-                    (xy -5.334 1.905)) 
-                (stroke 
-                    (width 0) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (polyline 
-                (pts 
-                    (xy -5.08 2.921) 
-                    (xy -1.27 2.921)) 
-                (stroke 
-                    (width 0) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (polyline 
-                (pts 
-                    (xy -5.08 2.159) 
-                    (xy -4.191 2.159)) 
-                (stroke 
-                    (width 0) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (arc 
-                (start -6.096 1.905) 
-                (mid -5.08 2.9068) 
-                (end -4.064 1.905) 
-                (stroke 
-                    (width 0) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (arc 
-                (start -5.334 1.8971) 
-                (mid -5.08 2.1295) 
-                (end -4.826 1.8971) 
-                (stroke 
-                    (width 0) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (arc 
-                (start -4.064 -1.905) 
-                (mid -5.08 -2.9068) 
-                (end -6.096 -1.905) 
-                (stroke 
-                    (width 0) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (arc 
-                (start -4.826 -1.905) 
-                (mid -5.08 -2.147) 
-                (end -5.334 -1.905) 
-                (stroke 
-                    (width 0) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (polyline 
-                (pts 
-                    (xy -5.08 -2.159) 
-                    (xy -4.191 -2.159)) 
-                (stroke 
-                    (width 0) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (polyline 
-                (pts 
-                    (xy -5.08 -2.921) 
-                    (xy -1.27 -2.921)) 
-                (stroke 
-                    (width 0) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (polyline 
-                (pts 
-                    (xy -4.826 -1.905) 
-                    (xy -4.826 1.905)) 
-                (stroke 
-                    (width 0) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (polyline 
-                (pts 
-                    (xy -4.064 1.905) 
-                    (xy -4.064 -1.905)) 
-                (stroke 
-                    (width 0) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (arc 
-                (start -1.27 2.921) 
-                (mid -0.5411 2.6339) 
-                (end -0.254 1.905) 
-                (stroke 
-                    (width 0) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (arc 
-                (start -0.254 -1.905) 
-                (mid -0.5409 -2.6341) 
-                (end -1.27 -2.921) 
-                (stroke 
-                    (width 0) 
-                    (type default)) 
-                (fill 
-                    (type none))) 
-            (polyline 
-                (pts 
-                    (xy -0.254 1.905) 
-                    (xy -0.254 -1.905)) 
-                (stroke 
-                    (width 0) 
-                    (type default)) 
-                (fill 
-                    (type none)))) 
-        (symbol "USB_C_Receptacle_USB2.0_14P_1_1" 
-            (pin passive line 
-                (at -11.43 10.16 0) 
-                (length 3.81) 
-                (name "VBUS" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "A4" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at -11.43 7.62 0) 
-                (length 3.81) 
-                (name "VBUS" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "B9" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at -11.43 -6.35 0) 
-                (length 3.81) 
-                (name "GND" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "A1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at -11.43 -8.89 0) 
-                (length 3.81) 
-                (name "GND" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "B1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at -11.43 -12.7 0) 
-                (length 3.81) 
-                (name "Shield" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "SH" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at 10.16 10.16 180) 
-                (length 3.81) 
-                (name "DP2" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "B6" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at 10.16 7.62 180) 
-                (length 3.81) 
-                (name "DP1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "A6" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at 10.16 5.08 180) 
-                (length 3.81) 
-                (name "DN1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "A7" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at 10.16 2.54 180) 
-                (length 3.81) 
-                (name "DN2" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "B7" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at 10.16 -2.54 180) 
-                (length 3.81) 
-                (name "SBU1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "A8" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at 10.16 -5.08 180) 
-                (length 3.81) 
-                (name "SBU2" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "B8" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at 10.16 -10.16 180) 
-                (length 3.81) 
-                (name "CC1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "A5" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin passive line 
-                (at 10.16 -12.7 180) 
-                (length 3.81) 
-                (name "CC2" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "B5" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))))) 
-        (embedded_fonts no)) 
-    (symbol "ZD25WQ16CEIGR" 
-        (exclude_from_sim no) 
-        (in_bom yes) 
-        (on_board yes) 
-        (property "Reference" "U" 
-            (at 0.635 3.175 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (justify left))) 
-        (property "Value" "ZD25WQ16CEIGR" 
-            (at 0.635 1.27 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (justify left))) 
-        (property "Footprint" "Package_SON:Winbond_USON-8-1EP_3x2mm_P0.5mm_EP0.2x1.6mm" 
-            (at 0 3.556 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "Datasheet" "https://www.lcsc.com/datasheet/C5353550.pdf" 
-            (at 0 5.842 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (property "Description" "16Mbit QSPI NOR flash memory" 
-            (at 0 1.27 0) 
-            (effects 
-                (font 
-                    (size 1.27 1.27)) 
-                (hide yes))) 
-        (symbol "ZD25WQ16CEIGR_1_1" 
-            (rectangle 
-                (start -6.35 0) 
-                (end 6.35 -20.32) 
-                (stroke 
-                    (width 0) 
-                    (type solid)) 
-                (fill 
-                    (type background))) 
-            (pin power_in line 
-                (at 0 2.54 270) 
-                (length 2.54) 
-                (name "VCC" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "8" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin power_in line 
-                (at 0 -22.86 90) 
-                (length 2.54) 
-                (name "VSS" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "4" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at 8.89 -2.54 180) 
-                (length 2.54) 
-                (name "SCK" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "6" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 8.89 -6.35 180) 
-                (length 2.54) 
-                (name "IO0" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "5" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 8.89 -8.89 180) 
-                (length 2.54) 
-                (name "IO1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "2" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 8.89 -11.43 180) 
-                (length 2.54) 
-                (name "IO2" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "3" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin bidirectional line 
-                (at 8.89 -13.97 180) 
-                (length 2.54) 
-                (name "IO3" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "7" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27))))) 
-            (pin input line 
-                (at 8.89 -17.78 180) 
-                (length 2.54) 
-                (name "~{CS}" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))) 
-                (number "1" 
-                    (effects 
-                        (font 
-                            (size 1.27 1.27)))))) 
-        (embedded_fonts no)))
+(kicad_symbol_lib
+	(version 20251024)
+	(generator "kicad_symbol_editor")
+	(generator_version "10.0")
+	(symbol "+19V"
+		(power global)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(duplicate_pin_numbers_are_jumpers no)
+		(property "Reference" "#PWR"
+			(at 0 -3.81 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "+19V"
+			(at 0 3.556 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+19V\""
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(symbol "+19V_0_1"
+			(polyline
+				(pts
+					(xy -0.762 1.27) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 2.54) (xy 0.762 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "+19V_1_1"
+			(pin power_in line
+				(at 0 0 90)
+				(length 0)
+				(name ""
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "BDFN3310A056R"
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(duplicate_pin_numbers_are_jumpers no)
+		(property "Reference" "U"
+			(at 0 -8.89 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "BDFN3310A056R"
+			(at 0 -10.414 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.016 1.016)
+				)
+			)
+		)
+		(property "Footprint" "Bluesat:UDFN8_3P3X1_517CB_ONS"
+			(at 1.524 12.192 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" "https://www.lcsc.com/datasheet/C600810.pdf"
+			(at 0.762 10.16 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "6-in-1 TVS diode for USB 3V3"
+			(at 1.27 14.224 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(symbol "BDFN3310A056R_1_0"
+			(pin power_in line
+				(at 11.43 -5.08 180)
+				(length 2.54)
+				(hide yes)
+				(name "GND"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at 11.43 -5.08 180)
+				(length 2.54)
+				(hide yes)
+				(name "GND"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "9"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at 11.43 -5.08 180)
+				(length 2.54)
+				(hide yes)
+				(name "GND"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "10"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(symbol "BDFN3310A056R_1_1"
+			(rectangle
+				(start -8.89 0)
+				(end 8.89 -7.62)
+				(stroke
+					(width 0)
+					(type solid)
+				)
+				(fill
+					(type background)
+				)
+			)
+			(pin input line
+				(at -6.35 2.54 270)
+				(length 2.54)
+				(name "IO1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -3.81 2.54 270)
+				(length 2.54)
+				(name "IO2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at 11.43 -5.08 180)
+				(length 2.54)
+				(name "GND"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -1.27 2.54 270)
+				(length 2.54)
+				(name "IO3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at 1.27 2.54 270)
+				(length 2.54)
+				(name "IO4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at 3.81 2.54 270)
+				(length 2.54)
+				(name "IO5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at 6.35 2.54 270)
+				(length 2.54)
+				(name "IO6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "8"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "C_CompactH"
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0.254)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(duplicate_pin_numbers_are_jumpers no)
+		(property "Reference" "C"
+			(at 0.762 0.889 0)
+			(show_name no)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.016 1.016)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "C_CompactH"
+			(at -0.762 0.889 0)
+			(show_name no)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.016 1.016)
+				)
+				(justify right)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Unpolarized capacitor, compact symbol"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "ki_keywords" "capacitor cap"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "ki_fp_filters" "C_*"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(symbol "C_CompactH_0_1"
+			(polyline
+				(pts
+					(xy -0.508 -1.524) (xy -0.508 1.524)
+				)
+				(stroke
+					(width 0.3048)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0.508 -1.524) (xy 0.508 1.524)
+				)
+				(stroke
+					(width 0.3302)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "C_CompactH_1_1"
+			(pin passive line
+				(at -2.54 0 0)
+				(length 2.032)
+				(name ""
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 2.54 0 180)
+				(length 2.032)
+				(name ""
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "C_CompactV"
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0.254)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(duplicate_pin_numbers_are_jumpers no)
+		(property "Reference" "C"
+			(at -0.889 0.762 90)
+			(show_name no)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.016 1.016)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "C_CompactV"
+			(at 0.889 0.762 90)
+			(show_name no)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.016 1.016)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 90)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 90)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Unpolarized capacitor, compact symbol"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "ki_keywords" "capacitor cap"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "ki_fp_filters" "C_*"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(symbol "C_CompactV_0_1"
+			(polyline
+				(pts
+					(xy 1.524 0.508) (xy -1.524 0.508)
+				)
+				(stroke
+					(width 0.3302)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 1.524 -0.508) (xy -1.524 -0.508)
+				)
+				(stroke
+					(width 0.3048)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "C_CompactV_1_1"
+			(pin passive line
+				(at 0 -2.54 90)
+				(length 2.032)
+				(name ""
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 0 2.54 270)
+				(length 2.032)
+				(name ""
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "DMHT6016LFJ"
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(duplicate_pin_numbers_are_jumpers no)
+		(property "Reference" "U"
+			(at 4.572 4.826 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "DMHT6016LFJ"
+			(at 7.874 9.144 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Bluesat:VDFN5045-12"
+			(at 0.508 -20.066 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" "https://www.diodes.com/assets/Datasheets/DMHT6016LFJ.pdf"
+			(at 0.254 -21.844 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "60V N-channel enhancement mode MOSFET H-bridge"
+			(at 0.762 -18.034 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(symbol "DMHT6016LFJ_1_1"
+			(rectangle
+				(start -12.7 7.62)
+				(end 12.7 -7.62)
+				(stroke
+					(width 0)
+					(type solid)
+				)
+				(fill
+					(type background)
+				)
+			)
+			(pin input line
+				(at -15.24 3.81 0)
+				(length 2.54)
+				(name "G1_AH"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at 0 10.16 270)
+				(length 2.54)
+				(name "D1/D4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_out line
+				(at 15.24 1.27 180)
+				(length 2.54)
+				(name "S1/D2_A"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -15.24 1.27 0)
+				(length 2.54)
+				(name "G2_AL"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -1.27 -10.16 90)
+				(length 2.54)
+				(name "S2_A"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -1.27 -10.16 90)
+				(length 2.54)
+				(hide yes)
+				(name "S2_A"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 1.27 -10.16 90)
+				(length 2.54)
+				(name "S3_B"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 1.27 -10.16 90)
+				(length 2.54)
+				(hide yes)
+				(name "S3_B"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "8"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -15.24 -3.81 0)
+				(length 2.54)
+				(name "G3_BL"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "9"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_out line
+				(at 15.24 -1.27 180)
+				(length 2.54)
+				(name "S4/D3_B"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "10"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at 0 10.16 270)
+				(length 2.54)
+				(hide yes)
+				(name "D1/D4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "11"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -15.24 -1.27 0)
+				(length 2.54)
+				(name "G4_BH"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "12"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at 0 10.16 270)
+				(length 2.54)
+				(hide yes)
+				(name "D1/D4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "A"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin free line
+				(at 15.24 1.27 180)
+				(length 2.54)
+				(hide yes)
+				(name "S1/D2_A"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "B"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin free line
+				(at 15.24 -1.27 180)
+				(length 2.54)
+				(hide yes)
+				(name "S4/D3_B"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "C"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "D_TVS_Dual_Compact"
+		(pin_names
+			(offset 1.016)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(duplicate_pin_numbers_are_jumpers no)
+		(property "Reference" "D"
+			(at 0 6.35 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.016 1.016)
+				)
+			)
+		)
+		(property "Value" "D_TVS_Dual_Compact"
+			(at 0 5.08 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.016 1.016)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Dual bidirectional transient-voltage-suppression diode, compact symbol (suggested: RCLAMP0502B)"
+			(at 0.254 12.7 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "ki_keywords" "diode TVS thyrector"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "ki_fp_filters" "TO-???* *_Diode_* *SingleDiode* D_*"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(symbol "D_TVS_Dual_Compact_0_1"
+			(polyline
+				(pts
+					(xy -1.27 1.27) (xy -1.27 -1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -1.27 -1.27) (xy -1.27 -1.905) (xy 1.27 -1.905) (xy 1.27 -1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -0.254 1.27) (xy -2.286 1.27) (xy -0.254 -1.27) (xy -2.286 -1.27) (xy -0.254 1.27)
+				)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -0.254 -0.508) (xy -0.254 0) (xy -2.286 0) (xy -2.286 0.508)
+				)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 1.27 1.27) (xy 1.27 -1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 2.286 1.27) (xy 0.254 1.27) (xy 2.286 -1.27) (xy 0.254 -1.27) (xy 2.286 1.27)
+				)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 2.286 -0.508) (xy 2.286 0) (xy 0.254 0) (xy 0.254 0.508)
+				)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "D_TVS_Dual_Compact_1_1"
+			(rectangle
+				(start -2.794 2.54)
+				(end 2.794 -2.54)
+				(stroke
+					(width 0)
+					(type solid)
+				)
+				(fill
+					(type background)
+				)
+			)
+			(polyline
+				(pts
+					(xy -1.27 1.27) (xy -1.27 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 -2.54) (xy 0 -1.905)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 1.27 2.54) (xy 1.27 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 1.27 2.54) (xy 1.27 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 1.27 1.27) (xy 1.27 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(pin passive line
+				(at -1.27 3.81 270)
+				(length 1.27)
+				(name ""
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 1.27 3.81 270)
+				(length 1.27)
+				(name ""
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 0 -3.81 90)
+				(length 1.27)
+				(name ""
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "D_TVS_Quad_Compact"
+		(pin_names
+			(offset 1.016)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(duplicate_pin_numbers_are_jumpers no)
+		(property "Reference" "D"
+			(at 0 6.35 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.016 1.016)
+				)
+			)
+		)
+		(property "Value" "D_TVS_Quad_Compact"
+			(at 0 5.08 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.016 1.016)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Quad bidirectional transient-voltage-suppression diode, compact symbol (suggested: TPAZ1143-04F)"
+			(at 0.254 12.7 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "ki_keywords" "diode TVS thyrector"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "ki_fp_filters" "TO-???* *_Diode_* *SingleDiode* D_*"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(symbol "D_TVS_Quad_Compact_0_1"
+			(polyline
+				(pts
+					(xy -3.81 1.27) (xy -3.81 -1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -2.794 1.27) (xy -4.826 1.27) (xy -2.794 -1.27) (xy -4.826 -1.27) (xy -2.794 1.27)
+				)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -2.794 -0.508) (xy -2.794 0) (xy -4.826 0) (xy -4.826 0.508)
+				)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -1.27 1.27) (xy -1.27 -1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -0.254 1.27) (xy -2.286 1.27) (xy -0.254 -1.27) (xy -2.286 -1.27) (xy -0.254 1.27)
+				)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -0.254 -0.508) (xy -0.254 0) (xy -2.286 0) (xy -2.286 0.508)
+				)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 1.27 1.27) (xy 1.27 -1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 2.286 1.27) (xy 0.254 1.27) (xy 2.286 -1.27) (xy 0.254 -1.27) (xy 2.286 1.27)
+				)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 2.286 -0.508) (xy 2.286 0) (xy 0.254 0) (xy 0.254 0.508)
+				)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 3.81 1.27) (xy 3.81 -1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 4.826 1.27) (xy 2.794 1.27) (xy 4.826 -1.27) (xy 2.794 -1.27) (xy 4.826 1.27)
+				)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 4.826 -0.508) (xy 4.826 0) (xy 2.794 0) (xy 2.794 0.508)
+				)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "D_TVS_Quad_Compact_1_1"
+			(rectangle
+				(start -5.334 2.54)
+				(end 5.334 -2.54)
+				(stroke
+					(width 0)
+					(type solid)
+				)
+				(fill
+					(type background)
+				)
+			)
+			(polyline
+				(pts
+					(xy -3.81 2.54) (xy -3.81 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -3.81 -1.905) (xy -3.81 -1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -3.81 -1.905) (xy 3.81 -1.905)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -1.27 1.27) (xy -1.27 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -1.27 -1.905) (xy -1.27 -1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 0 -2.54) (xy 0 -1.905)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 1.27 2.54) (xy 1.27 2.54)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 1.27 2.54) (xy 1.27 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 1.27 1.27) (xy 1.27 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 1.27 -1.905) (xy 1.27 -1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 3.81 2.54) (xy 3.81 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 3.81 -1.905) (xy 3.81 -1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 3.81 -1.905) (xy 3.81 -1.905)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(pin passive line
+				(at -3.81 3.81 270)
+				(length 1.27)
+				(name ""
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -1.27 3.81 270)
+				(length 1.27)
+				(name ""
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 0 -3.81 90)
+				(length 1.27)
+				(name ""
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 1.27 3.81 270)
+				(length 1.27)
+				(name ""
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 3.81 3.81 270)
+				(length 1.27)
+				(name ""
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 3.81 3.81 270)
+				(length 1.27)
+				(hide yes)
+				(name ""
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 1.27 3.81 270)
+				(length 1.27)
+				(hide yes)
+				(name ""
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 0 -3.81 90)
+				(length 1.27)
+				(hide yes)
+				(name ""
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "8"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -1.27 3.81 270)
+				(length 1.27)
+				(hide yes)
+				(name ""
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "9"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -3.81 3.81 270)
+				(length 1.27)
+				(hide yes)
+				(name ""
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "10"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "IDC_6P"
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(duplicate_pin_numbers_are_jumpers no)
+		(property "Reference" "J"
+			(at 0 7.366 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "IDC_6P"
+			(at 0 5.334 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Bluesat:IDC6"
+			(at 0 -5.842 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" "Bluesat OWR docs: standard/electrical/device#debugging"
+			(at -0.508 -7.62 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "6-pin IDC MCU debug header (socket for debuggers)"
+			(at 0 -6.604 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(symbol "IDC_6P_1_1"
+			(rectangle
+				(start -5.08 3.81)
+				(end 5.08 -3.81)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type background)
+				)
+			)
+			(pin input line
+				(at -8.89 2.54 0)
+				(length 3.81)
+				(name "SWO"
+					(effects
+						(font
+							(size 1.016 1.016)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin output line
+				(at 8.89 2.54 180)
+				(length 3.81)
+				(name "NRST"
+					(effects
+						(font
+							(size 1.016 1.016)
+						)
+					)
+				)
+				(number "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at -8.89 0 0)
+				(length 3.81)
+				(name "GND"
+					(effects
+						(font
+							(size 1.016 1.016)
+						)
+					)
+				)
+				(number "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at 8.89 0 180)
+				(length 3.81)
+				(name "3V3"
+					(effects
+						(font
+							(size 1.016 1.016)
+						)
+					)
+				)
+				(number "4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at -8.89 -2.54 0)
+				(length 3.81)
+				(name "SWDIO"
+					(effects
+						(font
+							(size 0.889 0.889)
+						)
+					)
+				)
+				(number "5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin output line
+				(at 8.89 -2.54 180)
+				(length 3.81)
+				(name "SWCLK"
+					(effects
+						(font
+							(size 0.889 0.889)
+						)
+					)
+				)
+				(number "6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "ISM330DLC"
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(duplicate_pin_numbers_are_jumpers no)
+		(property "Reference" "U"
+			(at 2.54 8.255 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "ISM330DLC"
+			(at 2.54 6.35 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Package_LGA:LGA-14_3x2.5mm_P0.5mm_LayoutBorder3x4y"
+			(at -0.254 -21.844 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" "https://www.lcsc.com/datasheet/C2943126.pdf"
+			(at -0.254 -24.13 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "6 Axis IMU (3 Axis Gyroscope + 3 Axis Accelerometer)"
+			(at -0.254 -19.558 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(symbol "ISM330DLC_1_1"
+			(rectangle
+				(start -7.62 5.08)
+				(end 7.62 -5.08)
+				(stroke
+					(width 0)
+					(type solid)
+				)
+				(fill
+					(type background)
+				)
+			)
+			(pin bidirectional line
+				(at 10.16 -2.54 180)
+				(length 2.54)
+				(name "SDO"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at -1.27 -7.62 90)
+				(length 2.54)
+				(name "RES"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -1.27 -7.62 90)
+				(length 2.54)
+				(hide yes)
+				(name "RES"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin output line
+				(at -10.16 2.54 0)
+				(length 2.54)
+				(name "INT1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at -1.27 7.62 270)
+				(length 2.54)
+				(name "VIO"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at 1.27 -7.62 90)
+				(length 2.54)
+				(name "GND"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at 1.27 -7.62 90)
+				(length 2.54)
+				(hide yes)
+				(name "GND"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at 1.27 7.62 270)
+				(length 2.54)
+				(name "VDD"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "8"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin output line
+				(at -10.16 0 0)
+				(length 2.54)
+				(name "INT2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "9"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin no_connect line
+				(at 5.08 -7.62 90)
+				(length 2.54)
+				(hide yes)
+				(name "NC"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "10"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin no_connect line
+				(at 2.54 -7.62 90)
+				(length 2.54)
+				(hide yes)
+				(name "NC"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "11"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -10.16 -2.54 0)
+				(length 2.54)
+				(name "CS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "12"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin open_collector line
+				(at 10.16 0 180)
+				(length 2.54)
+				(name "SCL"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "13"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin open_collector line
+				(at 10.16 2.54 180)
+				(length 2.54)
+				(name "SDA"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "14"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "LIS2MDL"
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(duplicate_pin_numbers_are_jumpers no)
+		(property "Reference" "U"
+			(at 1.905 8.255 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "LIS2MDL"
+			(at 1.905 6.35 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Package_LGA:LGA-12_2x2mm_P0.5mm"
+			(at -0.254 -11.938 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" "https://www.st.com/resource/en/datasheet/lis2mdl.pdf"
+			(at 0.254 -13.97 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "3-axis magnetometer (NOT ARCh-LEGAL)"
+			(at -0.254 -9.652 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(symbol "LIS2MDL_1_1"
+			(rectangle
+				(start -7.62 5.08)
+				(end 7.62 -5.08)
+				(stroke
+					(width 0)
+					(type solid)
+				)
+				(fill
+					(type background)
+				)
+			)
+			(text "THIS COMPONENT IS\nNOT ARCh-LEGAL"
+				(at -13.716 8.636 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(pin open_collector line
+				(at 10.16 0 180)
+				(length 2.54)
+				(name "SCL"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 0 -7.62 90)
+				(length 2.54)
+				(hide yes)
+				(name "NC"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -10.16 -2.54 0)
+				(length 2.54)
+				(name "CS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin open_collector line
+				(at 10.16 2.54 180)
+				(length 2.54)
+				(name "SDA"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -10.16 2.54 0)
+				(length 2.54)
+				(name "C1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at 0 -7.62 90)
+				(length 2.54)
+				(name "GND"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin output line
+				(at 10.16 -2.54 180)
+				(length 2.54)
+				(name "INT"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at 0 -7.62 90)
+				(length 2.54)
+				(hide yes)
+				(name "GND"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "8"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at 1.27 7.62 270)
+				(length 2.54)
+				(name "VDD"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "9"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at -1.27 7.62 270)
+				(length 2.54)
+				(name "VIO"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "10"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 0 -7.62 90)
+				(length 2.54)
+				(hide yes)
+				(name "NC"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "11"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 0 -7.62 90)
+				(length 2.54)
+				(hide yes)
+				(name "NC"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "12"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "LM5148"
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(duplicate_pin_numbers_are_jumpers no)
+		(property "Reference" "U"
+			(at 0 3.048 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "LM5148"
+			(at 0 1.27 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.016 1.016)
+				)
+			)
+		)
+		(property "Footprint" "Bluesat:RGY0024E-MFG"
+			(at 0 8.636 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" "https://www.lcsc.com/datasheet/C7470701.pdf"
+			(at 0 6.604 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Large (80V) buck converter"
+			(at 0 10.668 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(symbol "LM5148_1_0"
+			(pin passive line
+				(at 1.27 -31.75 90)
+				(length 2.54)
+				(hide yes)
+				(name "NC"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "25"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(symbol "LM5148_1_1"
+			(rectangle
+				(start -10.16 0)
+				(end 10.16 -29.21)
+				(stroke
+					(width 0)
+					(type solid)
+				)
+				(fill
+					(type background)
+				)
+			)
+			(pin passive line
+				(at 1.27 -31.75 90)
+				(length 2.54)
+				(hide yes)
+				(name "NC"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 1.27 -31.75 90)
+				(length 2.54)
+				(hide yes)
+				(name "NC"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -12.7 -24.13 0)
+				(length 2.54)
+				(name "CNFG"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -12.7 -26.67 0)
+				(length 2.54)
+				(name "RT"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin output line
+				(at -12.7 -21.59 0)
+				(length 2.54)
+				(name "EXTCOMP"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at 12.7 -24.13 180)
+				(length 2.54)
+				(name "FB"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at -1.27 -31.75 90)
+				(length 2.54)
+				(name "AGND"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_out line
+				(at -12.7 -7.62 0)
+				(length 2.54)
+				(name "VDDA"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "8"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_out line
+				(at -12.7 -5.08 0)
+				(length 2.54)
+				(name "VCC"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "9"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at 1.27 -31.75 90)
+				(length 2.54)
+				(name "PGND"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "10"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin output line
+				(at 12.7 -10.16 180)
+				(length 2.54)
+				(name "LO"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "11"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at -12.7 -2.54 0)
+				(length 2.54)
+				(name "VIN"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "12"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin output line
+				(at 12.7 -5.08 180)
+				(length 2.54)
+				(name "HO"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "13"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_out line
+				(at 12.7 -7.62 180)
+				(length 2.54)
+				(name "SW"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "14"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at 12.7 -2.54 180)
+				(length 2.54)
+				(name "CBOOT"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "15"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at -12.7 -12.7 0)
+				(length 2.54)
+				(name "VCCX"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "16"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin output line
+				(at -12.7 -15.24 0)
+				(length 2.54)
+				(name "PG"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "17"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -12.7 -17.78 0)
+				(length 2.54)
+				(name "PFM"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "18"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -12.7 -10.16 0)
+				(length 2.54)
+				(name "EN"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "19"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at 12.7 -13.97 180)
+				(length 2.54)
+				(name "ISNS+"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "20"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at 12.7 -16.51 180)
+				(length 2.54)
+				(name "VOUT"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "21"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 1.27 -31.75 90)
+				(length 2.54)
+				(hide yes)
+				(name "NC"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "22"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 1.27 -31.75 90)
+				(length 2.54)
+				(hide yes)
+				(name "NC"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "23"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 1.27 -31.75 90)
+				(length 2.54)
+				(hide yes)
+				(name "NC"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "24"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "MP2459GJ-Z-MS"
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(duplicate_pin_numbers_are_jumpers no)
+		(property "Reference" "U"
+			(at -7.62 6.35 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "MP2459GJ-Z-MS"
+			(at 2.54 6.35 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Package_TO_SOT_SMD:TSOT-23-6"
+			(at 0 -22.86 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" "https://www.lcsc.com/datasheet/lcsc_datasheet_2504101957_MSKSEMI-MP2459GJ-Z-MS_C45367195.pdf"
+			(at -0.254 -25.908 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Monolithic, step-down, switch mode converter with a built-in power MOSFET"
+			(at -0.508 -20.066 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "ki_keywords" "2A Buck DC/DC"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "ki_fp_filters" "TSOT?23*"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(symbol "MP2459GJ-Z-MS_0_1"
+			(rectangle
+				(start -7.62 5.08)
+				(end 7.62 -5.08)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type background)
+				)
+			)
+		)
+		(symbol "MP2459GJ-Z-MS_1_1"
+			(pin passive line
+				(at 10.16 0 180)
+				(length 2.54)
+				(name "BST"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at 0 -7.62 90)
+				(length 2.54)
+				(name "GND"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at 10.16 -2.54 180)
+				(length 2.54)
+				(name "FB"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -10.16 -2.54 0)
+				(length 2.54)
+				(name "EN"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at -10.16 2.54 0)
+				(length 2.54)
+				(name "IN"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin output line
+				(at 10.16 2.54 180)
+				(length 2.54)
+				(name "SW"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "NMOS_Heatsink"
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(duplicate_pin_numbers_are_jumpers no)
+		(property "Reference" "Q"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" ""
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(symbol "NMOS_Heatsink_0_1"
+			(polyline
+				(pts
+					(xy 2.794 10.795) (xy 2.794 6.985)
+				)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 2.794 8.89) (xy 0 8.89)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 3.302 11.176) (xy 3.302 10.16)
+				)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 3.302 9.398) (xy 3.302 8.382)
+				)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 3.302 7.62) (xy 3.302 6.604)
+				)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 3.302 7.112) (xy 5.842 7.112) (xy 5.842 10.668) (xy 3.302 10.668)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 3.556 8.89) (xy 4.572 9.271) (xy 4.572 8.509) (xy 3.556 8.89)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(circle
+				(center 4.191 8.89)
+				(radius 2.794)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 5.08 11.43) (xy 5.08 10.668)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(circle
+				(center 5.08 10.668)
+				(radius 0.254)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(circle
+				(center 5.08 7.112)
+				(radius 0.254)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(polyline
+				(pts
+					(xy 5.08 6.35) (xy 5.08 8.89) (xy 3.302 8.89)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 5.461 9.271) (xy 6.223 9.271)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 5.842 9.271) (xy 5.461 8.636) (xy 6.223 8.636) (xy 5.842 9.271)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "NMOS_Heatsink_1_1"
+			(pin input line
+				(at -2.54 8.89 0)
+				(length 2.54)
+				(name "G"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 5.08 13.97 270)
+				(length 2.54)
+				(name "D"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 5.08 3.81 90)
+				(length 2.54)
+				(name "S"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 5.08 13.97 270)
+				(length 2.54)
+				(hide yes)
+				(name "Heatsink"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "RT9742GGJ5"
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(duplicate_pin_numbers_are_jumpers no)
+		(property "Reference" "U"
+			(at 0 7.62 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "RT9742GGJ5"
+			(at 0 5.842 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.016 1.016)
+				)
+			)
+		)
+		(property "Footprint" "Package_TO_SOT_SMD:TSOT-23-5"
+			(at 0 -15.494 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" "https://www.lcsc.com/datasheet/C250547.pdf"
+			(at 0 -18.034 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "USB Positive Overvoltage Protection Controller with Internal PMOS FET and Overcurrent Protection, TSOP-5"
+			(at 0 -12.7 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "ki_keywords" "overvoltage protection USB"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "ki_fp_filters" "TSOP*1.65x3.05*P0.95*"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(symbol "RT9742GGJ5_0_1"
+			(rectangle
+				(start -7.62 5.08)
+				(end 7.62 -5.08)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type background)
+				)
+			)
+		)
+		(symbol "RT9742GGJ5_1_1"
+			(pin power_in line
+				(at -10.16 2.54 0)
+				(length 2.54)
+				(name "IN"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at 0 -7.62 90)
+				(length 2.54)
+				(name "GND"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -10.16 -2.54 0)
+				(length 2.54)
+				(name "EN"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin open_collector line
+				(at -10.16 0 0)
+				(length 2.54)
+				(name "~{FLAG}"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_out line
+				(at 10.16 2.54 180)
+				(length 2.54)
+				(name "OUT"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "R_CompactH"
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0.254)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(duplicate_pin_numbers_are_jumpers no)
+		(property "Reference" "R"
+			(at 1.8415 0.1905 0)
+			(show_name no)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.016 1.016)
+				)
+				(justify left bottom)
+			)
+		)
+		(property "Value" "R_CompactH"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 0.762 0.762)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 90)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 90)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Resistor, compact symbol"
+			(at -0.1905 0.1905 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "ki_keywords" "R resistor"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "ki_fp_filters" "R_*"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(symbol "R_CompactH_0_1"
+			(rectangle
+				(start -1.778 -0.762)
+				(end 1.778 0.762)
+				(stroke
+					(width 0.2032)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "R_CompactH_1_1"
+			(pin passive line
+				(at -2.54 0 0)
+				(length 0.762)
+				(name ""
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 2.54 0 180)
+				(length 0.762)
+				(name ""
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "R_CompactV"
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0.254)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(duplicate_pin_numbers_are_jumpers no)
+		(property "Reference" "R"
+			(at -0.889 0 90)
+			(show_name no)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.016 1.016)
+				)
+				(justify bottom)
+			)
+		)
+		(property "Value" "R_CompactV"
+			(at 0 0 90)
+			(show_name no)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 0.762 0.762)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Resistor, compact symbol"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "ki_keywords" "R resistor"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "ki_fp_filters" "R_*"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(symbol "R_CompactV_0_1"
+			(rectangle
+				(start -0.762 1.778)
+				(end 0.762 -1.778)
+				(stroke
+					(width 0.2032)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "R_CompactV_1_1"
+			(pin passive line
+				(at 0 2.54 270)
+				(length 0.762)
+				(name ""
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 0 -2.54 90)
+				(length 0.762)
+				(name ""
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "TCAN1462V"
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(duplicate_pin_numbers_are_jumpers no)
+		(property "Reference" "U"
+			(at 1.905 8.255 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "TCAN1462V"
+			(at 1.905 6.35 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Package_SO:SOIC-8_3.9x4.9mm_P1.27mm"
+			(at 0 -18.034 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" "https://www.ti.com/lit/ds/symlink/tcan1462-q1.pdf"
+			(at 0 -20.32 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "CAN FD Transceiver with Signal Improvement Capability (SIC)"
+			(at 0 -15.24 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(symbol "TCAN1462V_1_1"
+			(rectangle
+				(start -7.62 5.08)
+				(end 7.62 -5.08)
+				(stroke
+					(width 0)
+					(type solid)
+				)
+				(fill
+					(type background)
+				)
+			)
+			(pin input line
+				(at -10.16 0 0)
+				(length 2.54)
+				(name "TXD"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at 0 -7.62 90)
+				(length 2.54)
+				(name "GND"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at 1.27 7.62 270)
+				(length 2.54)
+				(name "VCC"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin output line
+				(at -10.16 2.54 0)
+				(length 2.54)
+				(name "RXD"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at -1.27 7.62 270)
+				(length 2.54)
+				(name "VIO"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at 10.16 -1.27 180)
+				(length 2.54)
+				(name "CANL"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at 10.16 1.27 180)
+				(length 2.54)
+				(name "CANH"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -10.16 -2.54 0)
+				(length 2.54)
+				(name "STB"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "8"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at 0 -7.62 90)
+				(length 2.54)
+				(hide yes)
+				(name "EP"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "9"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "TMC5160A-TA"
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(duplicate_pin_numbers_are_jumpers no)
+		(property "Reference" "U"
+			(at -9.144 46.228 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "TMC5160A-TA"
+			(at 4.318 46.228 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Package_QFP:TQFP-48-1EP_7x7mm_P0.5mm_EP5x5mm_ThermalVias"
+			(at 0 -50.8 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" "https://www.trinamic.com/fileadmin/assets/Products/ICs_Documents/TMC5160A_Datasheet_Rev1.14.pdf"
+			(at 0.762 -53.34 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "20A Driver for two-phase bipolar stepper motor, SPI, UART, TQFP-48"
+			(at -0.508 -48.26 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "ki_keywords" "stepper motor driver trinamic"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "ki_fp_filters" "TQFP*1EP*7x7mm*P0.5mm*"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(symbol "TMC5160A-TA_1_0"
+			(rectangle
+				(start -15.24 44.45)
+				(end 15.24 -44.45)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type background)
+				)
+			)
+		)
+		(symbol "TMC5160A-TA_1_1"
+			(pin output line
+				(at 17.78 -21.59 180)
+				(length 2.54)
+				(name "HB1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 17.78 -3.81 180)
+				(length 2.54)
+				(name "CB1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at -17.78 30.48 0)
+				(length 2.54)
+				(name "12VOUT"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at 0 46.99 270)
+				(length 2.54)
+				(name "VSA"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_out line
+				(at -17.78 27.94 0)
+				(length 2.54)
+				(name "5VOUT"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at 0 -46.99 90)
+				(length 2.54)
+				(name "GNDA"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 17.78 21.59 180)
+				(length 2.54)
+				(name "SRAL"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 17.78 24.13 180)
+				(length 2.54)
+				(name "SRAH"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "8"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 17.78 -39.37 180)
+				(length 2.54)
+				(name "SRBH"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "9"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 17.78 -41.91 180)
+				(length 2.54)
+				(name "SRBL"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "10"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -17.78 -41.91 0)
+				(length 2.54)
+				(name "TST_MODE"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "11"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -17.78 11.43 0)
+				(length 2.54)
+				(name "CLK"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "12"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -17.78 6.35 0)
+				(length 2.54)
+				(name "~{CS}/CFG3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "13"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -17.78 3.81 0)
+				(length 2.54)
+				(name "SCK/CFG2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "14"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -17.78 1.27 0)
+				(length 2.54)
+				(name "SDI/CFG1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "15"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at -17.78 -1.27 0)
+				(length 2.54)
+				(name "SDO/CFG0"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "16"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -17.78 -6.35 0)
+				(length 2.54)
+				(name "REFL/STEP"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "17"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -17.78 -8.89 0)
+				(length 2.54)
+				(name "REFR/DIR"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "18"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at -2.54 -46.99 90)
+				(length 2.54)
+				(name "GNDD"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "19"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at 2.54 46.99 270)
+				(length 2.54)
+				(name "VCC_IO"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "20"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -17.78 -36.83 0)
+				(length 2.54)
+				(name "SD_MODE"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "21"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -17.78 -39.37 0)
+				(length 2.54)
+				(name "SPI_MODE"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "22"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -17.78 -19.05 0)
+				(length 2.54)
+				(name "ENCB/DCEN/CFG4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "23"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -17.78 -16.51 0)
+				(length 2.54)
+				(name "ENCA/DCIN/CFG5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "24"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at -17.78 -13.97 0)
+				(length 2.54)
+				(name "ENCN/DCO/CFG6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "25"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at -17.78 -29.21 0)
+				(length 2.54)
+				(name "SWN/DIAG0"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "26"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at -17.78 -31.75 0)
+				(length 2.54)
+				(name "SWP/DIAG1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "27"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -17.78 -24.13 0)
+				(length 2.54)
+				(name "~{DRV_EN}"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "28"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at -17.78 22.86 0)
+				(length 2.54)
+				(name "VCC"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "29"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -2.54 -46.99 90)
+				(length 2.54)
+				(hide yes)
+				(name "GNDD"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "30"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -17.78 39.37 0)
+				(length 2.54)
+				(name "CPO"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "31"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -17.78 34.29 0)
+				(length 2.54)
+				(name "CPI"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "32"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at -2.54 46.99 270)
+				(length 2.54)
+				(name "VS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "33"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -17.78 41.91 0)
+				(length 2.54)
+				(name "VCP"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "34"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 17.78 8.89 180)
+				(length 2.54)
+				(name "CA2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "35"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin output line
+				(at 17.78 36.83 180)
+				(length 2.54)
+				(name "HA2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "36"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 17.78 3.81 180)
+				(length 2.54)
+				(name "BMA2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "37"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin output line
+				(at 17.78 34.29 180)
+				(length 2.54)
+				(name "LA2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "38"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin output line
+				(at 17.78 39.37 180)
+				(length 2.54)
+				(name "LA1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "39"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 17.78 12.7 180)
+				(length 2.54)
+				(name "BMA1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "40"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin output line
+				(at 17.78 41.91 180)
+				(length 2.54)
+				(name "HA1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "41"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 17.78 17.78 180)
+				(length 2.54)
+				(name "CA1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "42"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 17.78 -12.7 180)
+				(length 2.54)
+				(name "CB2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "43"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin output line
+				(at 17.78 -26.67 180)
+				(length 2.54)
+				(name "HB2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "44"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 17.78 -17.78 180)
+				(length 2.54)
+				(name "BMB2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "45"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin output line
+				(at 17.78 -29.21 180)
+				(length 2.54)
+				(name "LB2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "46"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin output line
+				(at 17.78 -24.13 180)
+				(length 2.54)
+				(name "LB1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "47"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 17.78 -8.89 180)
+				(length 2.54)
+				(name "BMB1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "48"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at 2.54 -46.99 90)
+				(length 2.54)
+				(name "EP"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "49"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "TPS1H200A"
+		(pin_names
+			(offset 0.254)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(duplicate_pin_numbers_are_jumpers no)
+		(property "Reference" "U"
+			(at 0 12.446 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+			)
+		)
+		(property "Value" "TPS1H200A"
+			(at -0.254 10.16 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+			)
+		)
+		(property "Footprint" "Bluesat:DGN0008D_N"
+			(at 0.508 -19.304 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+					(italic yes)
+				)
+			)
+		)
+		(property "Datasheet" "https://www.ti.com/lit/gpn/tps1h200a-q1"
+			(at 0.254 -16.764 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+					(italic yes)
+				)
+			)
+		)
+		(property "Description" "40-V 200-m? Single-Channel Smart High-Side Switch"
+			(at 0 -14.224 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "ki_locked" ""
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "ki_keywords" "TPS1H200AQDGNRQ1"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "ki_fp_filters" "DGN0008D_N DGN0008D_M DGN0008D_L"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(symbol "TPS1H200A_0_1"
+			(pin input line
+				(at -11.43 6.35 0)
+				(length 2.54)
+				(name "IN"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -11.43 0 0)
+				(length 2.54)
+				(name "DIAG_EN"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin open_collector line
+				(at -11.43 -2.54 0)
+				(length 2.54)
+				(name "FAULT_N"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 11.43 -6.35 180)
+				(length 2.54)
+				(name "DELAY"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at 0 -11.43 90)
+				(length 2.54)
+				(name "GND"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at -11.43 3.81 0)
+				(length 2.54)
+				(name "VS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "8"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(symbol "TPS1H200A_1_1"
+			(rectangle
+				(start -8.89 8.89)
+				(end 8.89 -8.89)
+				(stroke
+					(width 0)
+					(type solid)
+				)
+				(fill
+					(type background)
+				)
+			)
+			(pin passive line
+				(at -11.43 -6.35 0)
+				(length 2.54)
+				(name "CL"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_out line
+				(at 11.43 6.35 180)
+				(length 2.54)
+				(name "OUT"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 0 -11.43 90)
+				(length 2.54)
+				(hide yes)
+				(name "PAD"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "9"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "TPS61175"
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(duplicate_pin_numbers_are_jumpers no)
+		(property "Reference" "U"
+			(at 0 8.89 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" ""
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Bluesat:PowerPAD_HTSSOP-14_4.4x5.0-0.65-EP"
+			(at 0 12.954 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" "https://www.ti.com/lit/ds/symlink/tps61175.pdf"
+			(at 0 10.668 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "3-A High-Voltage Boost Converter With Soft Start and Programmable Switching Frequency"
+			(at 0 15.24 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(symbol "TPS61175_1_1"
+			(rectangle
+				(start -10.16 7.62)
+				(end 10.16 -7.62)
+				(stroke
+					(width 0)
+					(type solid)
+				)
+				(fill
+					(type background)
+				)
+			)
+			(pin power_out line
+				(at 12.7 5.08 180)
+				(length 2.54)
+				(name "SW"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 12.7 5.08 180)
+				(length 2.54)
+				(hide yes)
+				(name "SW"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at -12.7 5.08 0)
+				(length 2.54)
+				(name "VIN"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -12.7 2.54 0)
+				(length 2.54)
+				(name "EN"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -12.7 -2.54 0)
+				(length 2.54)
+				(name "SS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -12.7 -5.08 0)
+				(length 2.54)
+				(name "SYNC"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at -1.27 -10.16 90)
+				(length 2.54)
+				(name "AGND"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 12.7 -2.54 180)
+				(length 2.54)
+				(name "COMP"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "8"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at 12.7 0 180)
+				(length 2.54)
+				(name "FB"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "9"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -12.7 0 0)
+				(length 2.54)
+				(name "FREQ"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "10"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -1.27 -10.16 90)
+				(length 2.54)
+				(hide yes)
+				(name "NC"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "11"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at 1.27 -10.16 90)
+				(length 2.54)
+				(name "PGND"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "12"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at 1.27 -10.16 90)
+				(length 2.54)
+				(hide yes)
+				(name "PGND"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "13"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at 1.27 -10.16 90)
+				(length 2.54)
+				(hide yes)
+				(name "PGND"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "14"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at -1.27 -10.16 90)
+				(length 2.54)
+				(hide yes)
+				(name "EP"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "15"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "USB5744"
+		(pin_names
+			(offset 0.254)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(duplicate_pin_numbers_are_jumpers no)
+		(property "Reference" "U"
+			(at 0.254 3.556 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+			)
+		)
+		(property "Value" "USB5744"
+			(at 1.016 1.27 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+			)
+		)
+		(property "Footprint" "Bluesat:VQFN56_2G_MCH"
+			(at -0.254 -80.264 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+					(italic yes)
+				)
+			)
+		)
+		(property "Datasheet" "https://ww1.microchip.com/downloads/aemDocuments/documents/UNG/ProductDocuments/DataSheets/USB5744-Data-Sheet-DS00001855.pdf"
+			(at 0 -82.296 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+					(italic yes)
+				)
+			)
+		)
+		(property "Description" "USB v3.2 Hub (5 Gbps)"
+			(at 0 -77.978 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "ki_locked" ""
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "ki_keywords" "USB5744/2GX01"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "ki_fp_filters" "VQFN56_2G_MCH VQFN56_2G_MCH-M VQFN56_2G_MCH-L"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(symbol "USB5744_1_1"
+			(rectangle
+				(start -25.4 0)
+				(end 25.4 -73.66)
+				(stroke
+					(width 0)
+					(type solid)
+				)
+				(fill
+					(type background)
+				)
+			)
+			(pin bidirectional line
+				(at 27.94 -5.08 180)
+				(length 2.54)
+				(name "USB2DN_DP1/PRT_DIS_P1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 27.94 -2.54 180)
+				(length 2.54)
+				(name "USB2DN_DM1/PRT_DIS_M1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 27.94 -36.83 180)
+				(length 2.54)
+				(name "USB3DN_TXDP1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 27.94 -34.29 180)
+				(length 2.54)
+				(name "USB3DN_TXDM1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 27.94 -31.75 180)
+				(length 2.54)
+				(name "USB3DN_RXDP1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 27.94 -29.21 180)
+				(length 2.54)
+				(name "USB3DN_RXDM1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 27.94 -11.43 180)
+				(length 2.54)
+				(name "USB2DN_DP2/PRT_DIS_P2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "8"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 27.94 -8.89 180)
+				(length 2.54)
+				(name "USB2DN_DM2/PRT_DIS_M2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "9"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 27.94 -48.26 180)
+				(length 2.54)
+				(name "USB3DN_TXDP2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "10"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 27.94 -45.72 180)
+				(length 2.54)
+				(name "USB3DN_TXDM2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "11"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 27.94 -43.18 180)
+				(length 2.54)
+				(name "USB3DN_RXDP2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "13"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 27.94 -40.64 180)
+				(length 2.54)
+				(name "USB3DN_RXDM2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "14"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 27.94 -17.78 180)
+				(length 2.54)
+				(name "USB2DN_DP3/PRT_DIS_P3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "17"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 27.94 -15.24 180)
+				(length 2.54)
+				(name "USB2DN_DM3/PRT_DIS_M3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "18"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 27.94 -59.69 180)
+				(length 2.54)
+				(name "USB3DN_TXDP3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "19"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 27.94 -57.15 180)
+				(length 2.54)
+				(name "USB3DN_TXDM3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "20"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 27.94 -54.61 180)
+				(length 2.54)
+				(name "USB3DN_RXDP3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "22"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 27.94 -52.07 180)
+				(length 2.54)
+				(name "USB3DN_RXDM3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "23"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 27.94 -24.13 180)
+				(length 2.54)
+				(name "USB2DN_DP4/PRT_DIS_P4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "24"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 27.94 -21.59 180)
+				(length 2.54)
+				(name "USB2DN_DM4/PRT_DIS_M4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "25"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 27.94 -71.12 180)
+				(length 2.54)
+				(name "USB3DN_TXDP4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "26"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 27.94 -68.58 180)
+				(length 2.54)
+				(name "USB3DN_TXDM4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "27"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 27.94 -66.04 180)
+				(length 2.54)
+				(name "USB3DN_RXDP4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "29"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 27.94 -63.5 180)
+				(length 2.54)
+				(name "USB3DN_RXDM4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "30"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -27.94 -10.16 0)
+				(length 2.54)
+				(name "PRT_CTL4/GANG_PWR"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "32"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -27.94 -7.62 0)
+				(length 2.54)
+				(name "PRT_CTL3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "34"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -27.94 -5.08 0)
+				(length 2.54)
+				(name "PRT_CTL2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "35"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -27.94 -2.54 0)
+				(length 2.54)
+				(name "PRT_CTL1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "36"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -27.94 -35.56 0)
+				(length 2.54)
+				(name "VBUS_DET"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "37"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at -27.94 -40.64 0)
+				(length 2.54)
+				(name "SPI_CLK/SMCLK"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "38"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at -27.94 -43.18 0)
+				(length 2.54)
+				(name "SPI_DO/SMDAT"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "39"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at -27.94 -22.86 0)
+				(length 2.54)
+				(name "SPI_DI/CFG_BC_EN"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "40"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at -27.94 -20.32 0)
+				(length 2.54)
+				(name "SPI_CE_N/CFG_NON_REM"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "41"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -27.94 -71.12 0)
+				(length 2.54)
+				(name "RESET_N"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "42"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at -27.94 -50.8 0)
+				(length 2.54)
+				(name "USB2UP_DP"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "45"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at -27.94 -48.26 0)
+				(length 2.54)
+				(name "USB2UP_DM"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "46"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at -27.94 -63.5 0)
+				(length 2.54)
+				(name "USB3UP_TXDP"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "47"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at -27.94 -60.96 0)
+				(length 2.54)
+				(name "USB3UP_TXDM"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "48"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at -27.94 -58.42 0)
+				(length 2.54)
+				(name "USB3UP_RXDP"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "50"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at -27.94 -55.88 0)
+				(length 2.54)
+				(name "USB3UP_RXDM"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "51"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at -27.94 -17.78 0)
+				(length 2.54)
+				(name "ATEST_(GND)"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "52"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin output line
+				(at -27.94 -30.48 0)
+				(length 2.54)
+				(name "XTALO"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "53"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -27.94 -27.94 0)
+				(length 2.54)
+				(name "XTALI/CLK_IN"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "54"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -27.94 -15.24 0)
+				(length 2.54)
+				(name "RBIAS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "56"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(symbol "USB5744_2_1"
+			(rectangle
+				(start -10.16 0)
+				(end 10.16 -22.86)
+				(stroke
+					(width 0)
+					(type solid)
+				)
+				(fill
+					(type background)
+				)
+			)
+			(pin power_in line
+				(at -12.7 -2.54 0)
+				(length 2.54)
+				(name "VDD12"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at -12.7 -5.08 0)
+				(length 2.54)
+				(name "VDD12"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "12"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at -12.7 -7.62 0)
+				(length 2.54)
+				(name "VDD12"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "15"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at 12.7 -2.54 180)
+				(length 2.54)
+				(name "VDD33"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "16"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at -12.7 -10.16 0)
+				(length 2.54)
+				(name "VDD12"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "21"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at -12.7 -12.7 0)
+				(length 2.54)
+				(name "VDD12"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "28"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at 12.7 -5.08 180)
+				(length 2.54)
+				(name "VDD33"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "31"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at -12.7 -15.24 0)
+				(length 2.54)
+				(name "VDD12"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "33"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at -12.7 -17.78 0)
+				(length 2.54)
+				(name "VDD12"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "43"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at 12.7 -7.62 180)
+				(length 2.54)
+				(name "VDD33"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "44"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at -12.7 -20.32 0)
+				(length 2.54)
+				(name "VDD12"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "49"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at 12.7 -10.16 180)
+				(length 2.54)
+				(name "VDD33"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "55"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at 0 -25.4 90)
+				(length 2.54)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "57"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "USB7216C"
+		(pin_names
+			(offset 0.254)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(duplicate_pin_numbers_are_jumpers no)
+		(property "Reference" "U"
+			(at 0 6.096 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+			)
+		)
+		(property "Value" "USB7216CT/KDX"
+			(at 0.508 3.556 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+			)
+		)
+		(property "Footprint" "Bluesat:VQFN100_KDX_MCH"
+			(at 0 9.398 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+					(italic yes)
+				)
+			)
+		)
+		(property "Datasheet" "https://au.mouser.com/datasheet/3/282/1/USB7216C-Data-Sheet-DS00003851.pdf"
+			(at 0 6.858 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+					(italic yes)
+				)
+			)
+		)
+		(property "Description" "6-port USB v3.2 Gen 2 Hub (20 Gbps)"
+			(at 0 11.938 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "ki_locked" ""
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "ki_keywords" "USB7216C-I/KDX"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "ki_fp_filters" "VQFN100_KDX_MCH VQFN100_KDX_MCH-M VQFN100_KDX_MCH-L"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(symbol "USB7216C_1_1"
+			(rectangle
+				(start -25.4 0)
+				(end 25.4 -107.95)
+				(stroke
+					(width 0)
+					(type solid)
+				)
+				(fill
+					(type background)
+				)
+			)
+			(pin input line
+				(at -27.94 -105.41 0)
+				(length 2.54)
+				(name "RESET_N"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 27.94 -81.28 180)
+				(length 2.54)
+				(name "MSTR_I2C_CLK/PF30"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 27.94 -83.82 180)
+				(length 2.54)
+				(name "MSTR_I2C_DATA/PF31"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin unspecified line
+				(at 27.94 -15.24 180)
+				(length 2.54)
+				(name "DP1_VBUS_MON"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at -27.94 -68.58 0)
+				(length 2.54)
+				(name "USB2DN_DP1/PRT_DIS_P1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at -27.94 -66.04 0)
+				(length 2.54)
+				(name "USB2DN_DM1/PRT_DIS_M1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 27.94 -10.16 180)
+				(length 2.54)
+				(name "DP1_CC1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "12"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 27.94 -12.7 180)
+				(length 2.54)
+				(name "DP1_CC2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "13"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at -27.94 -93.98 0)
+				(length 2.54)
+				(name "USB2DN_DP5/PRT_DIS_P5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "14"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at -27.94 -91.44 0)
+				(length 2.54)
+				(name "USB2DN_DM5/PRT_DIS_M5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "15"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -27.94 -2.54 0)
+				(length 2.54)
+				(name "CFG_STRAP1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "21"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -27.94 -5.08 0)
+				(length 2.54)
+				(name "CFG_STRAP2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "22"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -27.94 -7.62 0)
+				(length 2.54)
+				(name "CFG_STRAP3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "23"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at -27.94 -38.1 0)
+				(length 2.54)
+				(name "TESTEN_(GND)"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "24"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at -27.94 -74.93 0)
+				(length 2.54)
+				(name "USB2DN_DP2/PRT_DIS_P2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "27"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at -27.94 -72.39 0)
+				(length 2.54)
+				(name "USB2DN_DM2/PRT_DIS_M2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "28"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at -27.94 -81.28 0)
+				(length 2.54)
+				(name "USB2DN_DP3/PRT_DIS_P3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "34"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at -27.94 -78.74 0)
+				(length 2.54)
+				(name "USB2DN_DM3/PRT_DIS_M3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "35"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at -27.94 -97.79 0)
+				(length 2.54)
+				(name "USB2DN_DM6/PRT_DIS_M6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "41"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at -27.94 -100.33 0)
+				(length 2.54)
+				(name "USB2DN_DP6/PRT_DIS_P6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "42"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 27.94 -27.94 180)
+				(length 2.54)
+				(name "DP1_VCONN2/PF3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "44"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 27.94 -30.48 180)
+				(length 2.54)
+				(name "DP1_VCONN1/PF4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "45"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 27.94 -33.02 180)
+				(length 2.54)
+				(name "DP1_DISCHARGE/PF5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "46"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 27.94 -35.56 180)
+				(length 2.54)
+				(name "GPIO70/PF6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "47"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 27.94 -38.1 180)
+				(length 2.54)
+				(name "GPIO71/PF7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "48"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 27.94 -40.64 180)
+				(length 2.54)
+				(name "GPIO72/PF8"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "49"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 27.94 -43.18 180)
+				(length 2.54)
+				(name "GPIO73/PF9"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "50"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 27.94 -45.72 180)
+				(length 2.54)
+				(name "PRT_CTL2_U3/PF10"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "51"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 27.94 -48.26 180)
+				(length 2.54)
+				(name "PRT_CTL3_U3/PF11"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "52"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 27.94 -50.8 180)
+				(length 2.54)
+				(name "PRT_CTL4_U3/PF12"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "54"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 27.94 -53.34 180)
+				(length 2.54)
+				(name "PRT_CTL4/PF13"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "56"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 27.94 -55.88 180)
+				(length 2.54)
+				(name "PRT_CTL3/PF14"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "57"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 27.94 -58.42 180)
+				(length 2.54)
+				(name "PRT_CTL2/PF15"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "58"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 27.94 -60.96 180)
+				(length 2.54)
+				(name "PRT_CTL5/PF16"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "59"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 27.94 -63.5 180)
+				(length 2.54)
+				(name "PRT_CTL1/PF17"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "60"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 27.94 -66.04 180)
+				(length 2.54)
+				(name "ALERT0/PF18"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "61"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -27.94 -49.53 0)
+				(length 2.54)
+				(name "TEST1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "63"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -27.94 -52.07 0)
+				(length 2.54)
+				(name "TEST2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "64"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -27.94 -54.61 0)
+				(length 2.54)
+				(name "TEST3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "65"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 27.94 -68.58 180)
+				(length 2.54)
+				(name "PF19"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "66"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at -27.94 -20.32 0)
+				(length 2.54)
+				(name "SPI_CLK/PF21"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "68"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at -27.94 -35.56 0)
+				(length 2.54)
+				(name "SPI_CE_N/CFG_NON_REM/PF20"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "69"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at -27.94 -24.13 0)
+				(length 2.54)
+				(name "SPI_D0/CFG_BC_EN/PF22"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "70"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at -27.94 -26.67 0)
+				(length 2.54)
+				(name "SPI_D1/PF23"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "71"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at -27.94 -29.21 0)
+				(length 2.54)
+				(name "SPI_D2/PF24"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "72"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at -27.94 -31.75 0)
+				(length 2.54)
+				(name "SPI_D3/PF25"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "73"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 27.94 -78.74 180)
+				(length 2.54)
+				(name "PF29"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "74"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 27.94 -71.12 180)
+				(length 2.54)
+				(name "SLV_I2C_CLK/PF26"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "75"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 27.94 -73.66 180)
+				(length 2.54)
+				(name "SLV_I2C_DATA/PF27"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "76"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 27.94 -76.2 180)
+				(length 2.54)
+				(name "PRT_CTL6/PF28"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "77"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 27.94 -17.78 180)
+				(length 2.54)
+				(name "VBUS_MON_UP"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "80"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at -27.94 -87.63 0)
+				(length 2.54)
+				(name "USB2DN_DP4/PRT_DIS_P4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "81"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at -27.94 -85.09 0)
+				(length 2.54)
+				(name "USB2DN_DM4/PRT_DIS_M4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "82"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at -27.94 -62.23 0)
+				(length 2.54)
+				(name "USB2UP_DP"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "89"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at -27.94 -59.69 0)
+				(length 2.54)
+				(name "USB2UP_DM"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "90"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin no_connect line
+				(at -27.94 -15.24 0)
+				(length 2.54)
+				(name "ATEST"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "96"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin output line
+				(at 27.94 -5.08 180)
+				(length 2.54)
+				(name "XTALO"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "97"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at 27.94 -2.54 180)
+				(length 2.54)
+				(name "XTALI/CLK_IN"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "98"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -27.94 -12.7 0)
+				(length 2.54)
+				(name "RBIAS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "100"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(symbol "USB7216C_2_1"
+			(rectangle
+				(start -10.16 0)
+				(end 10.16 -69.85)
+				(stroke
+					(width 0)
+					(type solid)
+				)
+				(fill
+					(type background)
+				)
+			)
+			(pin bidirectional line
+				(at 12.7 -21.59 180)
+				(length 2.54)
+				(name "USB3DN_TXDP1A"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 12.7 -19.05 180)
+				(length 2.54)
+				(name "USB3DN_TXDM1A"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "8"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 12.7 -16.51 180)
+				(length 2.54)
+				(name "USB3DN_RXDP1A"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "10"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 12.7 -13.97 180)
+				(length 2.54)
+				(name "USB3DN_RXDM1A"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "11"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 12.7 -33.02 180)
+				(length 2.54)
+				(name "USB3DN_TXDP1B"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "16"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 12.7 -30.48 180)
+				(length 2.54)
+				(name "USB3DN_TXDM1B"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "17"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 12.7 -27.94 180)
+				(length 2.54)
+				(name "USB3DN_RXDP1B"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "19"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 12.7 -25.4 180)
+				(length 2.54)
+				(name "USB3DN_RXDM1B"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "20"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 12.7 -44.45 180)
+				(length 2.54)
+				(name "USB3DN_TXDP2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "29"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 12.7 -41.91 180)
+				(length 2.54)
+				(name "USB3DN_TXDM2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "30"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 12.7 -39.37 180)
+				(length 2.54)
+				(name "USB3DN_RXDP2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "32"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 12.7 -36.83 180)
+				(length 2.54)
+				(name "USB3DN_RXDM2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "33"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 12.7 -55.88 180)
+				(length 2.54)
+				(name "USB3DN_TXDP3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "36"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 12.7 -53.34 180)
+				(length 2.54)
+				(name "USB3DN_TXDM3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "37"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 12.7 -50.8 180)
+				(length 2.54)
+				(name "USB3DN_RXDP3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "39"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 12.7 -48.26 180)
+				(length 2.54)
+				(name "USB3DN_RXDM3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "40"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 12.7 -67.31 180)
+				(length 2.54)
+				(name "USB3DN_TXDP4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "83"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 12.7 -64.77 180)
+				(length 2.54)
+				(name "USB3DN_TXDM4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "84"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 12.7 -62.23 180)
+				(length 2.54)
+				(name "USB3DN_RXDP4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "86"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 12.7 -59.69 180)
+				(length 2.54)
+				(name "USB3DN_RXDM4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "87"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 12.7 -10.16 180)
+				(length 2.54)
+				(name "USB3UP_TXDP"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "91"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 12.7 -7.62 180)
+				(length 2.54)
+				(name "USB3UP_TXDM"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "92"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 12.7 -5.08 180)
+				(length 2.54)
+				(name "USB3UP_RXDP"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "94"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 12.7 -2.54 180)
+				(length 2.54)
+				(name "USB3UP_RXDM"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "95"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(symbol "USB7216C_3_1"
+			(rectangle
+				(start -10.16 0)
+				(end 10.16 -25.4)
+				(stroke
+					(width 0)
+					(type solid)
+				)
+				(fill
+					(type background)
+				)
+			)
+			(pin power_in line
+				(at -12.7 -2.54 0)
+				(length 2.54)
+				(name "VCORE"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "9"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at -12.7 -5.08 0)
+				(length 2.54)
+				(name "VCORE"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "18"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at -12.7 -7.62 0)
+				(length 2.54)
+				(name "VCORE"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "25"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at 12.7 -2.54 180)
+				(length 2.54)
+				(name "VDD33"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "26"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at -12.7 -10.16 0)
+				(length 2.54)
+				(name "VCORE"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "31"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at -12.7 -12.7 0)
+				(length 2.54)
+				(name "VCORE"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "38"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at 12.7 -5.08 180)
+				(length 2.54)
+				(name "VDD33"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "43"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at 12.7 -7.62 180)
+				(length 2.54)
+				(name "VDD33"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "53"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at -12.7 -15.24 0)
+				(length 2.54)
+				(name "VCORE"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "55"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at 12.7 -10.16 180)
+				(length 2.54)
+				(name "VDD33"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "62"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at 12.7 -12.7 180)
+				(length 2.54)
+				(name "VDD33"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "67"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at -12.7 -17.78 0)
+				(length 2.54)
+				(name "VCORE"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "78"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at 12.7 -15.24 180)
+				(length 2.54)
+				(name "VDD33"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "79"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at -12.7 -20.32 0)
+				(length 2.54)
+				(name "VCORE"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "85"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at 12.7 -17.78 180)
+				(length 2.54)
+				(name "VDD33"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "88"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at -12.7 -22.86 0)
+				(length 2.54)
+				(name "VCORE"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "93"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at 12.7 -20.32 180)
+				(length 2.54)
+				(name "VDD33"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "99"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 0 -27.94 90)
+				(length 2.54)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "101"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "USB_C_Receptacle_USB2.0_14P"
+		(pin_names
+			(offset 1.016)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(duplicate_pin_numbers_are_jumpers no)
+		(property "Reference" "J**"
+			(at -0.635 19.05 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "USB_C_Receptacle_USB2.0_14P"
+			(at -0.635 16.51 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Bluesat:USB_C_Receptacle_USB2.0_14P"
+			(at 0 23.368 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" "https://www.lcsc.com/datasheet/C2765186.pdf"
+			(at 2.54 -20.32 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Type C USB2.0 Receptacle"
+			(at 0 -18.288 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "ki_keywords" "16-Pin, USB-C, Type C, USB 2.0, 0.8mm PCB, SMD, 5A, Paste in hole"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "ki_fp_filters" "Socket_GCT:USB4105_pasteInHole*"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(symbol "USB_C_Receptacle_USB2.0_14P_0_1"
+			(rectangle
+				(start -7.62 12.7)
+				(end 6.35 -15.24)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type background)
+				)
+			)
+			(polyline
+				(pts
+					(xy -6.096 1.905) (xy -6.096 -1.905)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -5.334 -1.905) (xy -5.334 1.905)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -5.08 2.921) (xy -1.27 2.921)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -5.08 2.159) (xy -4.191 2.159)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(arc
+				(start -6.096 1.905)
+				(mid -5.08 2.9068)
+				(end -4.064 1.905)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(arc
+				(start -5.334 1.8971)
+				(mid -5.08 2.1295)
+				(end -4.826 1.8971)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(arc
+				(start -4.064 -1.905)
+				(mid -5.08 -2.9068)
+				(end -6.096 -1.905)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(arc
+				(start -4.826 -1.905)
+				(mid -5.08 -2.147)
+				(end -5.334 -1.905)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -5.08 -2.159) (xy -4.191 -2.159)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -5.08 -2.921) (xy -1.27 -2.921)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -4.826 -1.905) (xy -4.826 1.905)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -4.064 1.905) (xy -4.064 -1.905)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(arc
+				(start -1.27 2.921)
+				(mid -0.5411 2.6339)
+				(end -0.254 1.905)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(arc
+				(start -0.254 -1.905)
+				(mid -0.5409 -2.6341)
+				(end -1.27 -2.921)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy -0.254 1.905) (xy -0.254 -1.905)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "USB_C_Receptacle_USB2.0_14P_1_1"
+			(pin passive line
+				(at -11.43 -6.35 0)
+				(length 3.81)
+				(name "GND"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "A1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -11.43 10.16 0)
+				(length 3.81)
+				(name "VBUS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "A4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 10.16 -10.16 180)
+				(length 3.81)
+				(name "CC1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "A5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 10.16 7.62 180)
+				(length 3.81)
+				(name "DP1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "A6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 10.16 5.08 180)
+				(length 3.81)
+				(name "DN1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "A7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 10.16 -2.54 180)
+				(length 3.81)
+				(name "SBU1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "A8"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -11.43 -8.89 0)
+				(length 3.81)
+				(name "GND"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "B1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 10.16 -12.7 180)
+				(length 3.81)
+				(name "CC2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "B5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 10.16 10.16 180)
+				(length 3.81)
+				(name "DP2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "B6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 10.16 2.54 180)
+				(length 3.81)
+				(name "DN2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "B7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 10.16 -5.08 180)
+				(length 3.81)
+				(name "SBU2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "B8"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -11.43 7.62 0)
+				(length 3.81)
+				(name "VBUS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "B9"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -11.43 -12.7 0)
+				(length 3.81)
+				(name "Shield"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "SH"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "ZD25WQ16CEIGR"
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(duplicate_pin_numbers_are_jumpers no)
+		(property "Reference" "U"
+			(at 0.635 3.175 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "ZD25WQ16CEIGR"
+			(at 0.635 1.27 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Package_SON:Winbond_USON-8-1EP_3x2mm_P0.5mm_EP0.2x1.6mm"
+			(at 0 3.556 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" "https://www.lcsc.com/datasheet/C5353550.pdf"
+			(at 0 5.842 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "16Mbit QSPI NOR flash memory"
+			(at 0 1.27 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(symbol "ZD25WQ16CEIGR_1_1"
+			(rectangle
+				(start -6.35 0)
+				(end 6.35 -20.32)
+				(stroke
+					(width 0)
+					(type solid)
+				)
+				(fill
+					(type background)
+				)
+			)
+			(pin input line
+				(at 8.89 -17.78 180)
+				(length 2.54)
+				(name "~{CS}"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 8.89 -8.89 180)
+				(length 2.54)
+				(name "IO1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 8.89 -11.43 180)
+				(length 2.54)
+				(name "IO2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at 0 -22.86 90)
+				(length 2.54)
+				(name "VSS"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 8.89 -6.35 180)
+				(length 2.54)
+				(name "IO0"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at 8.89 -2.54 180)
+				(length 2.54)
+				(name "SCK"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 8.89 -13.97 180)
+				(length 2.54)
+				(name "IO3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at 0 2.54 270)
+				(length 2.54)
+				(name "VCC"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "8"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+)


### PR DESCRIPTION
This might slightly break existing schematics!

- Changes pin types on a couple symbols (mainly IDC6); resolves #157.
- Add EEPROM (ZD24C128A) and LED (WS2812-2020)

Need to copy this over to the mini rover repo